### PR TITLE
feat: add optional colour coding for mailboxes

### DIFF
--- a/apps/web/components/dashboard/unified-mailbox-nav.tsx
+++ b/apps/web/components/dashboard/unified-mailbox-nav.tsx
@@ -1,21 +1,21 @@
 "use client";
 
-import Link from "next/link";
-import { useParams, usePathname } from "next/navigation";
-import { cn } from "@/lib/utils";
+import type { IdentityEntity, MailboxEntity } from "@db";
+import type { MailboxKind } from "@schema";
 import {
-	Inbox,
-	Send,
-	FileText,
 	Archive,
 	Ban,
-	Trash2,
+	FileText,
 	Folder,
+	Inbox,
 	Plus,
+	Send,
+	Trash2,
 } from "lucide-react";
-import { IdentityEntity, MailboxEntity } from "@db";
-import { FetchIdentityMailboxListResult } from "@/lib/actions/mailbox";
-import { MailboxKind } from "@schema";
+import Link from "next/link";
+import { useParams, usePathname } from "next/navigation";
+import type { FetchIdentityMailboxListResult } from "@/lib/actions/mailbox";
+import { cn } from "@/lib/utils";
 
 type Mailbox = {
 	slug: string | null;

--- a/apps/web/components/dashboard/unified-mailbox-nav.tsx
+++ b/apps/web/components/dashboard/unified-mailbox-nav.tsx
@@ -118,6 +118,12 @@ export function UnifiedMailboxNav({
 					isActive && "bg-sidebar-accent text-sidebar-accent-foreground",
 				)}
 			>
+				{m.mailbox.color ? (
+					<div
+						className="h-2.5 w-2.5 shrink-0 rounded-full"
+						style={{ backgroundColor: m.mailbox.color }}
+					/>
+				) : null}
 				<Icon className="h-4 w-4 shrink-0" />
 				<span className="min-w-0 truncate">
 					{m.mailbox.kind === "custom"

--- a/apps/web/components/mailbox/default/add-new-folder.tsx
+++ b/apps/web/components/mailbox/default/add-new-folder.tsx
@@ -1,13 +1,75 @@
+import { ActionIcon, ColorSwatch, Modal, Tooltip } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
-import { Modal, ActionIcon } from "@mantine/core";
-import { Plus } from "lucide-react";
+import { Plus, X } from "lucide-react";
 import * as React from "react";
 import { ReusableForm } from "@/components/common/reusable-form";
+import { useMailboxOptions } from "@/hooks/use-mailbox-options";
 import {
 	addNewMailboxFolder,
-	FetchIdentityMailboxListResult,
+	type FetchIdentityMailboxListResult,
 } from "@/lib/actions/mailbox";
-import { useMailboxOptions } from "@/hooks/use-mailbox-options";
+
+const FOLDER_COLORS = [
+	"#e03131",
+	"#e8590c",
+	"#f08c00",
+	"#2f9e44",
+	"#1971c2",
+	"#6741d9",
+	"#c2255c",
+	"#868e96",
+];
+
+function ColorPickerField({ name }: { name: string }) {
+	const [selected, setSelected] = React.useState<string | null>(null);
+
+	return (
+		<div>
+			<input type="hidden" name={name} value={selected ?? ""} />
+			<div className="flex items-center gap-2 flex-wrap">
+				{FOLDER_COLORS.map((color) => (
+					<button
+						key={color}
+						type="button"
+						onClick={() => setSelected(color === selected ? null : color)}
+						className="p-0 m-0 bg-transparent border-0 rounded-full"
+						style={{ lineHeight: 0 }}
+					>
+						<Tooltip label={color} withArrow>
+							<ColorSwatch
+								color={color}
+								size={20}
+								withShadow
+								className={`cursor-pointer transition-all ${
+									selected === color
+										? "ring-2 ring-offset-1 ring-[color:var(--color-brand-500)]"
+										: ""
+								}`}
+								style={{
+									transform: selected === color ? "scale(1.1)" : "scale(1)",
+								}}
+							/>
+						</Tooltip>
+					</button>
+				))}
+				{selected && (
+					<button
+						type="button"
+						onClick={() => setSelected(null)}
+						className="p-0 m-0 bg-transparent border-0 rounded-full"
+						style={{ lineHeight: 0 }}
+					>
+						<Tooltip label="No color" withArrow>
+							<ActionIcon size={20} variant="default" radius="xl">
+								<X className="h-3 w-3" />
+							</ActionIcon>
+						</Tooltip>
+					</button>
+				)}
+			</div>
+		</div>
+	);
+}
 
 export default function AddNewFolder({
 	mailboxes,
@@ -52,6 +114,14 @@ export default function AddNewFolder({
 					console.log("Selected parent folder:", val);
 				},
 			},
+		},
+		{
+			name: "color",
+			label: "Color (Optional)",
+			kind: "custom" as const,
+			component: ColorPickerField,
+			wrapperClasses: "col-span-12",
+			props: {},
 		},
 	];
 

--- a/apps/web/components/mailbox/default/mailbox-color-picker.tsx
+++ b/apps/web/components/mailbox/default/mailbox-color-picker.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { ActionIcon, ColorSwatch, Popover, Tooltip } from "@mantine/core";
+import { Paintbrush, X } from "lucide-react";
+import { useState, useTransition } from "react";
+import { updateMailboxColor } from "@/lib/actions/mailbox";
+
+const MAILBOX_COLORS = [
+	"#e03131",
+	"#e8590c",
+	"#f08c00",
+	"#2f9e44",
+	"#1971c2",
+	"#6741d9",
+	"#c2255c",
+	"#868e96",
+];
+
+export function MailboxColorPicker({
+	mailboxId,
+	currentColor,
+}: {
+	mailboxId: string;
+	currentColor: string | null;
+}) {
+	const [opened, setOpened] = useState(false);
+	const [pending, startTransition] = useTransition();
+
+	const handleSelect = (color: string | null) => {
+		startTransition(async () => {
+			await updateMailboxColor(mailboxId, color);
+			setOpened(false);
+		});
+	};
+
+	return (
+		<Popover
+			opened={opened}
+			onChange={setOpened}
+			position="bottom"
+			withArrow
+			shadow="md"
+		>
+			<Popover.Target>
+				<ActionIcon
+					size={16}
+					variant="subtle"
+					onClick={(e: React.MouseEvent) => {
+						e.preventDefault();
+						e.stopPropagation();
+						setOpened((o) => !o);
+					}}
+					aria-label="Set mailbox color"
+					className="opacity-0 group-hover:opacity-100 transition-opacity"
+				>
+					{currentColor ? (
+						<ColorSwatch color={currentColor} size={12} />
+					) : (
+						<Paintbrush className="h-3 w-3" />
+					)}
+				</ActionIcon>
+			</Popover.Target>
+
+			<Popover.Dropdown>
+				<div className="flex flex-wrap gap-2 p-1 max-w-[160px]">
+					{MAILBOX_COLORS.map((color) => (
+						<button
+							key={color}
+							type="button"
+							onClick={() => handleSelect(color)}
+							disabled={pending}
+							className="p-0 m-0 bg-transparent border-0 rounded-full"
+							style={{ lineHeight: 0 }}
+						>
+							<Tooltip label={color} withArrow>
+								<ColorSwatch
+									color={color}
+									size={20}
+									withShadow
+									className={`cursor-pointer transition-all ${
+										currentColor === color
+											? "ring-2 ring-offset-1 ring-[color:var(--color-brand-500)]"
+											: ""
+									}`}
+									style={{
+										transform:
+											currentColor === color ? "scale(1.1)" : "scale(1)",
+									}}
+								/>
+							</Tooltip>
+						</button>
+					))}
+					{currentColor && (
+						<button
+							type="button"
+							onClick={() => handleSelect(null)}
+							disabled={pending}
+							className="p-0 m-0 bg-transparent border-0 rounded-full"
+							style={{ lineHeight: 0 }}
+						>
+							<Tooltip label="Remove color" withArrow>
+								<ActionIcon size={20} variant="default" radius="xl">
+									<X className="h-3 w-3" />
+								</ActionIcon>
+							</Tooltip>
+						</button>
+					)}
+				</div>
+			</Popover.Dropdown>
+		</Popover>
+	);
+}

--- a/apps/web/components/mailbox/default/mailbox-nav.tsx
+++ b/apps/web/components/mailbox/default/mailbox-nav.tsx
@@ -1,35 +1,29 @@
 "use client";
 
-import Link from "next/link";
-import { useParams, usePathname } from "next/navigation";
-import { Badge } from "@/components/ui/badge";
-import { cn } from "@/lib/utils";
+import type { MailboxEntity } from "@db";
 import {
-	Inbox,
-	Send,
-	FileText,
 	Archive,
 	Ban,
-	Trash2,
+	FileText,
 	Folder,
-	Plus,
+	Inbox,
+	Send,
+	Trash2,
 } from "lucide-react";
-import { MailboxEntity } from "@db";
+import Link from "next/link";
+import { useParams, usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
+import { MailboxColorPicker } from "./mailbox-color-picker";
 
-type Mailbox = {
-	slug: string | null;
-	kind:
-		| "inbox"
-		| "sent"
-		| "drafts"
-		| "archive"
-		| "spam"
-		| "trash"
-		| "outbox"
-		| "custom";
-	name?: string | null;
-	unreadCount?: number | null;
-};
+type MailboxKind =
+	| "inbox"
+	| "sent"
+	| "drafts"
+	| "archive"
+	| "spam"
+	| "trash"
+	| "outbox"
+	| "custom";
 
 export function MailboxNav({
 	mailboxes,
@@ -43,7 +37,7 @@ export function MailboxNav({
 	const pathname = usePathname();
 	const params = useParams() as { mailboxSlug?: string };
 
-	const systemOrder: Mailbox["kind"][] = [
+	const systemOrder: MailboxKind[] = [
 		"inbox",
 		"starred" as any, // if you add later
 		"drafts",
@@ -51,9 +45,9 @@ export function MailboxNav({
 		"archive",
 		"spam",
 		"trash",
-	].filter(Boolean) as Mailbox["kind"][];
+	].filter(Boolean) as MailboxKind[];
 
-	const iconFor: Record<Mailbox["kind"], React.ElementType> = {
+	const iconFor: Record<MailboxKind, React.ElementType> = {
 		inbox: Inbox,
 		sent: Send,
 		drafts: FileText,
@@ -71,7 +65,7 @@ export function MailboxNav({
 
 	const custom = mailboxes.filter((m) => m.kind === "custom");
 
-	const Item = ({ m }: { m: Mailbox }) => {
+	const Item = ({ m }: { m: MailboxEntity }) => {
 		const Icon = iconFor[m.kind] ?? Folder;
 		const slug = m.slug ?? "inbox";
 		const href = `/mail/${identityPublicId}/${slug}`;
@@ -88,18 +82,19 @@ export function MailboxNav({
 					isActive && "bg-sidebar-accent text-sidebar-accent-foreground",
 				)}
 			>
+				{m.color ? (
+					<div
+						className="h-2.5 w-2.5 shrink-0 rounded-full"
+						style={{ backgroundColor: m.color }}
+					/>
+				) : null}
 				<Icon className="h-4 w-4 shrink-0" />
 				<span className="min-w-0 truncate">
 					{m.kind === "custom" ? (m.name ?? "Label") : titleFor(m.kind)}
 				</span>
-				{m.unreadCount ? (
-					<Badge
-						variant={isActive ? "secondary" : "outline"}
-						className="ml-auto"
-					>
-						{m.unreadCount}
-					</Badge>
-				) : null}
+				<span className="ml-auto">
+					<MailboxColorPicker mailboxId={m.id} currentColor={m.color} />
+				</span>
 			</Link>
 		);
 	};
@@ -115,7 +110,7 @@ export function MailboxNav({
 	);
 }
 
-function titleFor(kind: Mailbox["kind"]) {
+function titleFor(kind: MailboxKind) {
 	switch (kind) {
 		case "inbox":
 			return "Inbox";

--- a/apps/web/components/mailbox/default/mailbox-nav.tsx
+++ b/apps/web/components/mailbox/default/mailbox-nav.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { MailboxEntity } from "@db";
+import type { MailboxKind } from "@schema";
 import {
 	Archive,
 	Ban,
@@ -14,16 +15,6 @@ import Link from "next/link";
 import { useParams, usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { MailboxColorPicker } from "./mailbox-color-picker";
-
-type MailboxKind =
-	| "inbox"
-	| "sent"
-	| "drafts"
-	| "archive"
-	| "spam"
-	| "trash"
-	| "outbox"
-	| "custom";
 
 export function MailboxNav({
 	mailboxes,

--- a/apps/web/lib/actions/mailbox.ts
+++ b/apps/web/lib/actions/mailbox.ts
@@ -1013,6 +1013,10 @@ export async function addNewMailboxFolder(
 			decodedForm.parentId && decodedForm.parentId !== "none"
 				? String(decodedForm.parentId)
 				: null;
+		const color =
+			decodedForm.color && String(decodedForm.color).trim()
+				? String(decodedForm.color).trim()
+				: null;
 
 		if (parentId) {
 			const [parent] = await db
@@ -1036,6 +1040,7 @@ export async function addNewMailboxFolder(
 				name,
 				slug: slugify(name.toLowerCase()),
 				isDefault: false,
+				color,
 				metaData: {},
 			})
 			.returning();
@@ -1409,4 +1414,27 @@ export async function oneClickUnsubscribe(
 
 
 
+}
+
+export async function updateMailboxColor(
+	mailboxId: string,
+	color: string | null,
+) {
+	const user = await isSignedIn();
+	if (!user) throw new Error("Not authenticated");
+
+	const [mailbox] = await db
+		.select({ id: mailboxes.id })
+		.from(mailboxes)
+		.where(and(eq(mailboxes.id, mailboxId), eq(mailboxes.ownerId, user.id)))
+		.limit(1);
+
+	if (!mailbox) throw new Error("Mailbox not found");
+
+	await db
+		.update(mailboxes)
+		.set({ color, updatedAt: new Date() })
+		.where(eq(mailboxes.id, mailboxId));
+
+	revalidatePath("/dashboard/mail");
 }

--- a/apps/web/lib/actions/mailbox.ts
+++ b/apps/web/lib/actions/mailbox.ts
@@ -1,50 +1,50 @@
 "use server";
 
-import { cache } from "react";
-import { rlsClient } from "@/lib/actions/clients";
+import { PAGE_SIZE } from "@common/mail-client";
 import {
-    db,
-    DraftMessageInsertSchema,
-    draftMessages,
-    identities,
-    mailboxes,
-    mailboxSync,
-    mailboxThreads, mailSubscriptions,
-    messageAttachments,
-    messages,
-    threads,
+	DraftMessageInsertSchema,
+	db,
+	draftMessages,
+	identities,
+	mailboxes,
+	mailboxSync,
+	mailboxThreads,
+	mailSubscriptions,
+	messageAttachments,
+	messages,
+	threads,
 } from "@db";
+import {
+	type FormState,
+	getServerEnv,
+	handleAction,
+	type SearchThreadsResponse,
+} from "@schema";
+import slugify from "@sindresorhus/slugify";
+import dayjs from "dayjs";
+import { decode } from "decode-formdata";
 import {
 	and,
 	asc,
 	count,
 	desc,
 	eq,
+	gt,
 	inArray,
 	isNotNull,
 	isNull,
 	lte,
 	or,
 	sql,
-	gt,
 } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
-import {
-	FormState,
-	getServerEnv,
-	handleAction,
-	SearchThreadsResponse,
-} from "@schema";
-import { decode } from "decode-formdata";
-import { toArray } from "@/lib/utils";
-
-import Typesense, { Client } from "typesense";
-import { isSignedIn } from "@/lib/actions/auth";
-import slugify from "@sindresorhus/slugify";
 import { redirect } from "next/navigation";
-import { PAGE_SIZE } from "@common/mail-client";
+import { cache } from "react";
+import Typesense, { type Client } from "typesense";
+import { isSignedIn } from "@/lib/actions/auth";
+import { rlsClient } from "@/lib/actions/clients";
 import { getRedis } from "@/lib/actions/get-redis";
-import dayjs from "dayjs";
+import { toArray } from "@/lib/utils";
 
 let typeSenseClient: Client | null = null;
 function getTypeSenseClient(): Client {
@@ -1299,121 +1299,116 @@ export const fetchIdentitySnoozedThreads = async (identityPublicId: string) => {
 	return { threads };
 };
 
-
-
 function subscriptionKeyFromHeadersJson(headersJson: any) {
-    const list = headersJson?.list ?? null;
-    const rawListId = String(headersJson?.["list-id"] ?? "").trim() || null;
+	const list = headersJson?.list ?? null;
+	const rawListId = String(headersJson?.["list-id"] ?? "").trim() || null;
 
-    let unsubscribeHttpUrl: string | null = null;
+	let unsubscribeHttpUrl: string | null = null;
 
-    const fromList = list?.unsubscribe?.url || list?.unsubscribe?.href;
-    if (typeof fromList === "string" && fromList) unsubscribeHttpUrl = fromList;
+	const fromList = list?.unsubscribe?.url || list?.unsubscribe?.href;
+	if (typeof fromList === "string" && fromList) unsubscribeHttpUrl = fromList;
 
-    const fromHeader = headersJson?.["list-unsubscribe"];
-    if (!unsubscribeHttpUrl && typeof fromHeader === "string") {
-        const parts = fromHeader
-            .split(",")
-            .map((s: string) => s.trim().replace(/^<|>$/g, ""));
-        const http = parts.find((p: string) => /^https?:/i.test(p));
-        if (http) unsubscribeHttpUrl = http;
-    }
+	const fromHeader = headersJson?.["list-unsubscribe"];
+	if (!unsubscribeHttpUrl && typeof fromHeader === "string") {
+		const parts = fromHeader
+			.split(",")
+			.map((s: string) => s.trim().replace(/^<|>$/g, ""));
+		const http = parts.find((p: string) => /^https?:/i.test(p));
+		if (http) unsubscribeHttpUrl = http;
+	}
 
-    if (rawListId) {
-        const cleaned = rawListId
-            .replace(/^<|>$/g, "")
-            .replace(/\s+/g, "")
-            .toLowerCase();
-        return cleaned ? `list-id:${cleaned}` : null;
-    }
+	if (rawListId) {
+		const cleaned = rawListId
+			.replace(/^<|>$/g, "")
+			.replace(/\s+/g, "")
+			.toLowerCase();
+		return cleaned ? `list-id:${cleaned}` : null;
+	}
 
-    if (unsubscribeHttpUrl) {
-        try {
-            const u = new URL(unsubscribeHttpUrl);
-            const p = (u.pathname || "/").replace(/\/+$/, "") || "/";
-            return `${u.protocol}//${u.host.toLowerCase()}${p}`;
-        } catch {
-            return null;
-        }
-    }
+	if (unsubscribeHttpUrl) {
+		try {
+			const u = new URL(unsubscribeHttpUrl);
+			const p = (u.pathname || "/").replace(/\/+$/, "") || "/";
+			return `${u.protocol}//${u.host.toLowerCase()}${p}`;
+		} catch {
+			return null;
+		}
+	}
 
-    return null;
+	return null;
 }
 
 export async function fetchThreadMailSubscriptions(opts: {
-    ownerId: string;
-    messages: Array<{ id: string; headersJson: any }>;
+	ownerId: string;
+	messages: Array<{ id: string; headersJson: any }>;
 }) {
-    const keysByMessageId = new Map<string, string>();
+	const keysByMessageId = new Map<string, string>();
 
-    for (const m of opts.messages) {
-        const key = subscriptionKeyFromHeadersJson(m.headersJson);
-        if (key) keysByMessageId.set(m.id, key);
-    }
+	for (const m of opts.messages) {
+		const key = subscriptionKeyFromHeadersJson(m.headersJson);
+		if (key) keysByMessageId.set(m.id, key);
+	}
 
-    const uniqueKeys = Array.from(new Set(keysByMessageId.values()));
-    if (!uniqueKeys.length) {
-        return { byMessageId: new Map<string, any>(), keysByMessageId };
-    }
+	const uniqueKeys = Array.from(new Set(keysByMessageId.values()));
+	if (!uniqueKeys.length) {
+		return { byMessageId: new Map<string, any>(), keysByMessageId };
+	}
 
-    const rows = await db
-        .select()
-        .from(mailSubscriptions)
-        .where(
-            and(
-                eq(mailSubscriptions.ownerId, opts.ownerId),
-                inArray(mailSubscriptions.subscriptionKey, uniqueKeys),
-            ),
-        );
+	const rows = await db
+		.select()
+		.from(mailSubscriptions)
+		.where(
+			and(
+				eq(mailSubscriptions.ownerId, opts.ownerId),
+				inArray(mailSubscriptions.subscriptionKey, uniqueKeys),
+			),
+		);
 
-    const byKey = new Map(rows.map((r) => [r.subscriptionKey, r]));
-    const byMessageId = new Map<string, any>();
+	const byKey = new Map(rows.map((r) => [r.subscriptionKey, r]));
+	const byMessageId = new Map<string, any>();
 
-    for (const [messageId, key] of keysByMessageId.entries()) {
-        byMessageId.set(messageId, byKey.get(key) ?? null);
-    }
+	for (const [messageId, key] of keysByMessageId.entries()) {
+		byMessageId.set(messageId, byKey.get(key) ?? null);
+	}
 
-    return { byMessageId, keysByMessageId };
+	return { byMessageId, keysByMessageId };
 }
 
 export type FetchThreadMailSubsResult = Awaited<
-    ReturnType<typeof fetchThreadMailSubscriptions>
+	ReturnType<typeof fetchThreadMailSubscriptions>
 >;
 
-
 export async function oneClickUnsubscribe(
-    _prev: FormState,
-    formData: FormData,
+	_prev: FormState,
+	formData: FormData,
 ): Promise<FormState> {
-    return handleAction(async () => {
-        const decodedForm = decode(formData);
-        const id = String(decodedForm.mailSubscriptionId);
-        const [sub] = await db
-            .select()
-            .from(mailSubscriptions)
-            .where(and(eq(mailSubscriptions.id, id)))
-            .limit(1);
-        if (!sub?.unsubscribeHttpUrl) return { success: false, error: "Subscription not found" };
-        await fetch(sub.unsubscribeHttpUrl, {
-            method: "POST",
-            headers: { "Content-Type": "application/x-www-form-urlencoded" },
-            body: "List-Unsubscribe=One-Click",
-            redirect: "follow",
-        });
-        await db
-            .update(mailSubscriptions)
-            .set({
-                status: "unsubscribed",
-                unsubscribedAt: new Date(),
-                updatedAt: new Date(),
-            })
-            .where(eq(mailSubscriptions.id, id));
-        revalidatePath(String(decodedForm.pathname));
-        return { success: true };
-    });
-
-
-
+	return handleAction(async () => {
+		const decodedForm = decode(formData);
+		const id = String(decodedForm.mailSubscriptionId);
+		const [sub] = await db
+			.select()
+			.from(mailSubscriptions)
+			.where(and(eq(mailSubscriptions.id, id)))
+			.limit(1);
+		if (!sub?.unsubscribeHttpUrl)
+			return { success: false, error: "Subscription not found" };
+		await fetch(sub.unsubscribeHttpUrl, {
+			method: "POST",
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+			body: "List-Unsubscribe=One-Click",
+			redirect: "follow",
+		});
+		await db
+			.update(mailSubscriptions)
+			.set({
+				status: "unsubscribed",
+				unsubscribedAt: new Date(),
+				updatedAt: new Date(),
+			})
+			.where(eq(mailSubscriptions.id, id));
+		revalidatePath(String(decodedForm.pathname));
+		return { success: true };
+	});
 }
 
 export async function updateMailboxColor(

--- a/packages/db/src/drizzle/0015_add_mailbox_color.sql
+++ b/packages/db/src/drizzle/0015_add_mailbox_color.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "mailboxes" ADD COLUMN "color" text;

--- a/packages/db/src/drizzle/schema.ts
+++ b/packages/db/src/drizzle/schema.ts
@@ -452,6 +452,7 @@ export const mailboxes = pgTable(
 		name: text("name"),
 		slug: text("slug"),
 		isDefault: boolean("is_default").notNull().default(false),
+		color: text("color"),
 		metaData: jsonb("meta").$type<Record<string, any> | null>().default(null),
 		createdAt: timestamp("created_at", { withTimezone: true })
 			.defaultNow()


### PR DESCRIPTION
Closes #278

Adds optional colour coding for mailboxes - a small colour dot in the sidebar and a popover picker that appears on hover.

**What this does:**
- Adds a nullable `color` column to the mailboxes table (+ migration)
- New `MailboxColorPicker` component - 8 preset Mantine swatches, popover on hover
- Colour dots render in both the per-identity sidebar and the unified view
- Optional colour picker in the "new folder" form
- Server action with auth + ownership check

Happy to adjust the palette, dot size, or approach if you'd prefer something different.