### PR TITLE
Quality: Non-null assertions on potentially undefined env vars will crash at module load

### DIFF
--- a/packages/common/src/common-utils.ts
+++ b/packages/common/src/common-utils.ts
@@ -12,13 +12,17 @@ const {
     S3_FORCE_PATH_STYLE,
 } = getServerEnv();
 
+if (!S3_REGION || !S3_ACCESS_KEY || !S3_SECRET_KEY) {
+    throw new Error(`Missing required S3 environment variables: ${!S3_REGION ? 'S3_REGION' : ''} ${!S3_ACCESS_KEY ? 'S3_ACCESS_KEY' : ''} ${!S3_SECRET_KEY ? 'S3_SECRET_KEY' : ''}`.trim());
+}
+
 export const s3 = new S3Client({
-    region: S3_REGION!,
+    region: S3_REGION,
     endpoint: S3_ENDPOINT,
     forcePathStyle: String(S3_FORCE_PATH_STYLE) === "true",
     credentials: {
-        accessKeyId: S3_ACCESS_KEY!,
-        secretAccessKey: S3_SECRET_KEY!,
+        accessKeyId: S3_ACCESS_KEY,
+        secretAccessKey: S3_SECRET_KEY,
     },
 });
 


### PR DESCRIPTION
## Problem

`getServerEnv()` likely returns an object where properties may be `undefined` if
the corresponding env vars are missing. The non-null assertions (`!`) on
`S3_REGION`, `S3_ACCESS_KEY`, and `S3_SECRET_KEY` will silently pass `undefined`
to the S3 client constructor, which will only fail later at runtime when an actual
S3 operation is attempted — producing a confusing error far from the root cause.
Unlike the `drizzle.config.ts` file which wraps with `String()`, these values
are asserted non-null without any validation, so a missing env var crashes
with an opaque AWS SDK error instead of a clear startup failure.


**Severity**: `high`
**File**: `packages/common/src/common-utils.ts`

## Solution

Add explicit validation at module init so the process fails fast with a clear message:


## Changes

- `packages/common/src/common-utils.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
