### PR TITLE
feat(web): edit daily IMAP quota from identity settings (#312)

### DIFF
--- a/apps/web/app/[locale]/w/[wPublicId]/dashboard/(unified)/(mail)/mail/[identityPublicId]/settings/page.tsx
+++ b/apps/web/app/[locale]/w/[wPublicId]/dashboard/(unified)/(mail)/mail/[identityPublicId]/settings/page.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import SettingsGeneral from "@/components/mailbox/settings/settings-general";
-import { FormState, handleAction } from "@schema";
+import SettingsQuota from "@/components/mailbox/settings/settings-quota";
+import { FormState, handleAction, defaultImapQuota } from "@schema";
 import { decode } from "decode-formdata";
 import { rlsClient } from "@/lib/actions/clients";
-import { identities } from "@db";
+import { identities, type IdentityEntity } from "@db";
 import { eq } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 
@@ -12,12 +13,12 @@ async function Page({params}: {params: Promise<Record<string, string>>}) {
 
     const paramsResolved = await params;
     const rls = await rlsClient();
-    const [identity] = await rls((tx) =>
+    const [identity] = (await rls((tx) =>
         tx
             .select()
             .from(identities)
             .where(eq(identities.publicId, paramsResolved.identityPublicId))
-    );
+    )) as IdentityEntity[];
 
     const updateName = async (_prev: FormState, formData: FormData): Promise<FormState> => {
         "use server";
@@ -37,7 +38,37 @@ async function Page({params}: {params: Promise<Record<string, string>>}) {
         })
     }
 
-    return <SettingsGeneral updateName={updateName} identity={identity} />
+    const updateDailyQuota = async (_prev: FormState, formData: FormData): Promise<FormState> => {
+        "use server";
+        return handleAction(async () => {
+            const decodedForm = decode(formData);
+            const dailyQuota = Number(decodedForm.dailyQuota) || defaultImapQuota;
+            const rls = await rlsClient();
+            const [current] = await rls((tx) =>
+                tx
+                    .select({ metaData: identities.metaData })
+                    .from(identities)
+                    .where(eq(identities.id, decodedForm.id as string))
+            );
+            await rls((tx) =>
+                tx
+                    .update(identities)
+                    .set({
+                        metaData: { ...(current?.metaData ?? {}), dailyQuota },
+                    })
+                    .where(eq(identities.id, decodedForm.id as string)),
+            );
+            revalidatePath(String(decodedForm.pathname))
+            return {success: true, message: "Daily IMAP quota updated."};
+        })
+    }
+
+    return (
+        <>
+            <SettingsGeneral updateName={updateName} identity={identity} />
+            <SettingsQuota updateDailyQuota={updateDailyQuota} identity={identity} />
+        </>
+    )
 }
 
 export default Page;

--- a/apps/web/components/mailbox/settings/settings-quota.tsx
+++ b/apps/web/components/mailbox/settings/settings-quota.tsx
@@ -1,0 +1,65 @@
+"use client";
+import React from "react";
+import SectionCard from "@/components/mailbox/settings/settings-section-card";
+import { IdentityEntity } from "@db";
+import { ReusableForm } from "@/components/common/reusable-form";
+import { FormState, imapQuotaList, defaultImapQuota } from "@schema";
+import { usePathname } from "next/navigation";
+
+type UpdateDailyQuotaAction = (_prev: FormState, formData: FormData) => Promise<FormState>;
+
+function SettingsQuota({ updateDailyQuota, identity }: {updateDailyQuota: UpdateDailyQuotaAction, identity: IdentityEntity}) {
+
+    const pathname = usePathname()
+    const currentQuota = Number(identity.metaData?.dailyQuota) || defaultImapQuota;
+
+    const fields = [
+        {
+            name: "dailyQuota",
+            label: "Daily IMAP quota",
+            labelSuffix: "Used for backfilling older mails",
+            kind: "select" as const,
+            options: imapQuotaList.map((quota) => {
+                return {
+                    label: quota.label,
+                    value: String(quota.value),
+                };
+            }),
+            wrapperClasses: "col-span-12",
+            props: {
+                defaultValue: String(currentQuota),
+                className: "w-full",
+            },
+        },
+        {
+            name: "id",
+            wrapperClasses: "hidden",
+            props: { hidden: true, defaultValue: identity.id },
+        },
+        {
+            name: "pathname",
+            wrapperClasses: "hidden",
+            props: { hidden: true, defaultValue: pathname },
+        },
+    ];
+
+    return <>
+        <SectionCard
+            title="Daily IMAP quota"
+            description="Limit how much mail is backfilled from the server each day."
+        >
+
+            <ReusableForm
+                fields={fields}
+                action={updateDailyQuota}
+                submitButtonProps={{
+                    wrapperClasses: "flex items-center justify-end my-4 py-3",
+                    submitLabel: "Save changes",
+                }}
+            />
+
+        </SectionCard>
+    </>
+}
+
+export default SettingsQuota;


### PR DESCRIPTION
## Summary

Adds the ability to change an identity's **Daily IMAP quota** after creation, directly from the identity **Settings** page. Previously the quota (which bounds how much older mail is backfilled per day) could only be chosen when the identity was created — there was no way to adjust it afterwards.

Resolves #312.

## Changes

- **New `SettingsQuota` section** on the identity settings page, with a quota selector (reusing the existing `imapQuotaList` options) and a **Save changes** button. It mirrors the structure/UX of the existing `SettingsGeneral` section.
- **New `updateDailyQuota` server action** that merges `dailyQuota` into the identity's `meta`, mirroring the existing `updateName` action (same `handleAction` + `rlsClient` + `revalidatePath` pattern).

## How it works

The selector is prefilled with the identity's current quota (falling back to `defaultImapQuota`). Saving writes `metaData.dailyQuota` — the **same field** the create flow sets (`addNewEmailIdentity`) and that the worker's `getDailyQuota` reads for backfill — so the change takes effect on the next backfill cycle.

## Testing

- `pnpm --filter @kurrier/web exec tsc --noEmit` passes with no new type errors.
- Confirmed the written field (`metaData.dailyQuota`) matches what `apps/worker/lib/imap/backfill/backfill-full.ts` consumes.
