### PR TITLE
Add REST API endpoints to provision SMTP accounts and email identities

### DIFF
--- a/apps/docs/content/docs/api/api-routes/identities.mdx
+++ b/apps/docs/content/docs/api/api-routes/identities.mdx
@@ -30,6 +30,43 @@ status, and metadata.
 
 ---
 
+## Create an email identity
+
+### `POST /identities`
+
+Creates an **email identity** backed by an [SMTP account](/docs/api/api-routes/smtp-accounts),
+assigns it to workspace members, and — when the SMTP account has IMAP settings —
+kicks off mailbox discovery, backfill, and live sync, exactly like adding the
+identity from the dashboard.
+
+```json
+{
+	"value": "user@example.com",
+	"displayName": "User Example",
+	"smtpAccountId": "0d63d43a-2b3f-4f8e-9a76-2f0f2c9a3b1e"
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| **value** *(required)* | The email address of the identity. |
+| **smtpAccountId** *(required)* | The SMTP account that backs this identity. Must belong to the API key owner. |
+| **displayName** *(optional)* | Display name used when sending. |
+| **sharedWithWorkspace** *(optional)* | Share the identity with all workspace members. Defaults to `false`. |
+| **memberIds** *(optional)* | Workspace member user ids granted access. Defaults to the key owner. Ignored when `sharedWithWorkspace` is `true`. |
+| **dailyQuota** *(optional)* | Daily sending quota. Defaults to the standard IMAP quota. |
+
+The response contains the created identity plus a `backfill` field:
+
+- `"completed"` — IMAP mailbox discovery finished and message backfill + IDLE sync were queued
+- `"skipped"` — the SMTP account has no IMAP settings (send-only)
+- `"failed"` — mailbox discovery failed or timed out (check the account's IMAP credentials; the identity is still created)
+
+Returns `409 IDENTITY_EXISTS` if an email identity with the same address
+already exists in the workspace.
+
+---
+
 ## List identities
 
 ### `GET /identities`

--- a/apps/docs/content/docs/api/api-routes/meta.json
+++ b/apps/docs/content/docs/api/api-routes/meta.json
@@ -1,5 +1,5 @@
 {
 	"title": "Routes",
 	"defaultOpen": true,
-	"pages": ["me", "email", "webhooks", "identities"]
+	"pages": ["me", "email", "webhooks", "identities", "smtp-accounts"]
 }

--- a/apps/docs/content/docs/api/api-routes/smtp-accounts.mdx
+++ b/apps/docs/content/docs/api/api-routes/smtp-accounts.mdx
@@ -1,0 +1,115 @@
+---
+title: SMTP Accounts
+description: Provision SMTP/IMAP accounts through Kurrier's unified API
+---
+
+SMTP accounts hold the **connection settings and credentials** for a custom
+SMTP/IMAP mail host (cPanel, Office365, OVH, Zimbra, and most other providers).
+Once created, an SMTP account can back one or more [email identities](/docs/api/api-routes/identities).
+
+These endpoints let you **provision mail accounts entirely from your backend** —
+for example to onboard users automatically — instead of clicking through the
+dashboard. Credentials are encrypted at rest with `APP_SECRET_ENCRYPTION_KEY`,
+exactly like accounts created through the UI, and both stay interchangeable.
+
+All routes below are relative to:
+
+```text
+https://your-domain.com/api/kurrier
+```
+
+For authentication, see the [authentication guide](/docs/api/authentication).
+
+---
+
+## Create an SMTP account
+
+### `POST /smtp-accounts`
+
+```json
+{
+	"label": "OVH mail account",
+	"smtp": {
+		"host": "ssl0.ovh.net",
+		"port": 465,
+		"secure": true,
+		"username": "user@example.com",
+		"password": "app-password"
+	},
+	"imap": {
+		"host": "ssl0.ovh.net",
+		"port": 993,
+		"secure": true,
+		"username": "user@example.com",
+		"password": "app-password"
+	}
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| **label** *(required)* | Free-form name shown in the dashboard. |
+| **smtp** *(required)* | Outgoing mail settings: `host`, `port`, `username`, `password`, plus optional `secure` (implicit TLS, e.g. port 465 — leave unset/false for STARTTLS on 587) and `pool`. |
+| **imap** *(optional)* | Incoming mail settings: `host`, `port`, `username`, `password`, optional `secure` (defaults to true). Only needed if you want to receive/sync messages. |
+
+Passwords are **never returned** by the API — responses only carry connection
+metadata:
+
+```json
+{
+	"success": true,
+	"data": {
+		"id": "0d63d43a-2b3f-4f8e-9a76-2f0f2c9a3b1e",
+		"label": "OVH mail account",
+		"smtp": { "host": "ssl0.ovh.net", "port": 465, "username": "user@example.com", "secure": true, "pool": false },
+		"imap": { "host": "ssl0.ovh.net", "port": 993, "username": "user@example.com", "secure": true },
+		"sendVerified": null,
+		"receiveVerified": null
+	}
+}
+```
+
+---
+
+## List SMTP accounts
+
+### `GET /smtp-accounts`
+
+Returns all SMTP accounts owned by the authenticated user.
+
+---
+
+## Get a single SMTP account
+
+### `GET /smtp-accounts/{id}`
+
+Fetch a single SMTP account by id.
+
+---
+
+## Update an SMTP account
+
+### `PATCH /smtp-accounts/{id}`
+
+Partially update the label or connection settings. Only the fields you send are
+changed — omitted fields (including passwords) keep their current values.
+
+```json
+{
+	"smtp": { "password": "rotated-password" },
+	"imap": { "password": "rotated-password" }
+}
+```
+
+Pass `"imap": null` to remove the IMAP settings entirely.
+
+---
+
+## Delete an SMTP account
+
+### `DELETE /smtp-accounts/{id}`
+
+Permanently deletes the account and its encrypted credentials.
+
+Returns `409 ACCOUNT_IN_USE` (with the list of offending identities) if the
+account still backs one or more identities — delete those first.

--- a/apps/worker/lib/smtp-account-helpers.ts
+++ b/apps/worker/lib/smtp-account-helpers.ts
@@ -1,0 +1,168 @@
+import crypto from "node:crypto";
+import { db, decryptAdminSecrets, smtpAccountSecrets, smtpAccounts } from "@db";
+import type { SmtpAccountCreateInput, SmtpAccountUpdateInput } from "@schema";
+import { and, eq } from "drizzle-orm";
+import { createError } from "h3";
+
+// Secrets are stored with the same env-style keys the dashboard form
+// produces (see SMTP_SPEC in @schema), so accounts created through the
+// API and through the UI stay interchangeable.
+export type StoredSmtpConfig = Record<string, string>;
+
+const boolToString = (v: boolean | undefined) =>
+	v === undefined ? undefined : v ? "true" : "false";
+
+function cleanConfig(config: Record<string, string | undefined>) {
+	return Object.fromEntries(
+		Object.entries(config).filter(([, v]) => v !== undefined && v !== ""),
+	) as StoredSmtpConfig;
+}
+
+export function smtpConfigFromInput(
+	input: SmtpAccountCreateInput,
+	base?: { ulid?: string; label?: string },
+): StoredSmtpConfig {
+	return cleanConfig({
+		ulid: base?.ulid ?? crypto.randomUUID(),
+		label: base?.label ?? input.label,
+		SMTP_HOST: input.smtp.host,
+		SMTP_PORT: String(input.smtp.port),
+		SMTP_USERNAME: input.smtp.username,
+		SMTP_PASSWORD: input.smtp.password,
+		SMTP_SECURE: boolToString(input.smtp.secure),
+		SMTP_POOL: boolToString(input.smtp.pool),
+		IMAP_HOST: input.imap?.host,
+		IMAP_PORT: input.imap ? String(input.imap.port) : undefined,
+		IMAP_USERNAME: input.imap?.username,
+		IMAP_PASSWORD: input.imap?.password,
+		IMAP_SECURE: boolToString(input.imap?.secure),
+	});
+}
+
+export function applySmtpConfigUpdate(
+	existing: StoredSmtpConfig,
+	input: SmtpAccountUpdateInput,
+): StoredSmtpConfig {
+	const next: Record<string, string | undefined> = { ...existing };
+
+	if (input.label !== undefined) next.label = input.label;
+
+	if (input.smtp) {
+		if (input.smtp.host !== undefined) next.SMTP_HOST = input.smtp.host;
+		if (input.smtp.port !== undefined) next.SMTP_PORT = String(input.smtp.port);
+		if (input.smtp.username !== undefined)
+			next.SMTP_USERNAME = input.smtp.username;
+		if (input.smtp.password !== undefined)
+			next.SMTP_PASSWORD = input.smtp.password;
+		if (input.smtp.secure !== undefined)
+			next.SMTP_SECURE = boolToString(input.smtp.secure);
+		if (input.smtp.pool !== undefined)
+			next.SMTP_POOL = boolToString(input.smtp.pool);
+	}
+
+	if (input.imap === null) {
+		delete next.IMAP_HOST;
+		delete next.IMAP_PORT;
+		delete next.IMAP_USERNAME;
+		delete next.IMAP_PASSWORD;
+		delete next.IMAP_SECURE;
+	} else if (input.imap) {
+		if (input.imap.host !== undefined) next.IMAP_HOST = input.imap.host;
+		if (input.imap.port !== undefined) next.IMAP_PORT = String(input.imap.port);
+		if (input.imap.username !== undefined)
+			next.IMAP_USERNAME = input.imap.username;
+		if (input.imap.password !== undefined)
+			next.IMAP_PASSWORD = input.imap.password;
+		if (input.imap.secure !== undefined)
+			next.IMAP_SECURE = boolToString(input.imap.secure);
+	}
+
+	return cleanConfig(next);
+}
+
+// Passwords never leave the API: only connection metadata is exposed.
+export function serializeSmtpAccount(
+	account: {
+		id: string;
+		ownerId: string;
+		workspaceId: string;
+		createdAt: Date | string;
+		updatedAt: Date | string;
+	},
+	config: StoredSmtpConfig | null,
+) {
+	return {
+		id: account.id,
+		ownerId: account.ownerId,
+		workspaceId: account.workspaceId,
+		label: config?.label ?? null,
+		smtp: config?.SMTP_HOST
+			? {
+					host: config.SMTP_HOST,
+					port: config.SMTP_PORT ? Number(config.SMTP_PORT) : null,
+					username: config.SMTP_USERNAME ?? null,
+					secure: config.SMTP_SECURE === "true",
+					pool: config.SMTP_POOL === "true",
+				}
+			: null,
+		imap: config?.IMAP_HOST
+			? {
+					host: config.IMAP_HOST,
+					port: config.IMAP_PORT ? Number(config.IMAP_PORT) : null,
+					username: config.IMAP_USERNAME ?? null,
+					secure: config.IMAP_SECURE !== "false",
+				}
+			: null,
+		sendVerified: (config as Record<string, unknown>)?.sendVerified ?? null,
+		receiveVerified:
+			(config as Record<string, unknown>)?.receiveVerified ?? null,
+		createdAt: account.createdAt,
+		updatedAt: account.updatedAt,
+	};
+}
+
+export async function validateSmtpAccountOwnership(opts: {
+	accountId: string;
+	ownerId: string;
+}) {
+	const [account] = await db
+		.select()
+		.from(smtpAccounts)
+		.where(
+			and(
+				eq(smtpAccounts.id, opts.accountId),
+				eq(smtpAccounts.ownerId, opts.ownerId),
+			),
+		)
+		.limit(1);
+
+	if (!account) {
+		throw createError({
+			statusCode: 404,
+			statusMessage: "SMTP account not found or access denied",
+		});
+	}
+
+	return account;
+}
+
+export async function getSmtpAccountSecret(opts: {
+	accountId: string;
+	ownerId: string;
+}) {
+	const [row] = await decryptAdminSecrets({
+		linkTable: smtpAccountSecrets,
+		foreignCol: smtpAccountSecrets.accountId,
+		secretIdCol: smtpAccountSecrets.secretId,
+		ownerId: opts.ownerId,
+		parentId: opts.accountId,
+	});
+
+	if (!row) return null;
+
+	const config: StoredSmtpConfig = row.vault?.decrypted_secret
+		? JSON.parse(row.vault.decrypted_secret)
+		: {};
+
+	return { secretId: row.metaId, config };
+}

--- a/apps/worker/server/routes/api/kurrier/identities/index.post.ts
+++ b/apps/worker/server/routes/api/kurrier/identities/index.post.ts
@@ -1,0 +1,220 @@
+import {
+	db,
+	identities,
+	workspaceIdentityMembers,
+	workspaceMembers,
+	workspaces,
+} from "@db";
+import { defaultImapQuota, IdentityCreateApiSchema } from "@schema";
+import { and, eq, inArray } from "drizzle-orm";
+import { defineEventHandler } from "h3";
+import {
+	apiError,
+	apiSuccess,
+	validateApiKey,
+	validateJSONBody,
+} from "../../../../../lib/api-helpers";
+import { getRedis } from "../../../../../lib/get-redis";
+import {
+	getSmtpAccountSecret,
+	validateSmtpAccountOwnership,
+} from "../../../../../lib/smtp-account-helpers";
+
+const BACKFILL_DISCOVER_TIMEOUT_MS = 60_000;
+
+async function grantIdentityMembers(
+	identity: { id: string; workspaceId: string },
+	userIds: string[],
+) {
+	if (!userIds.length) return;
+
+	await db
+		.insert(workspaceIdentityMembers)
+		.values(
+			userIds.map((userId) => ({
+				identityId: identity.id,
+				workspaceId: identity.workspaceId,
+				userId,
+			})),
+		)
+		.onConflictDoNothing();
+}
+
+// Mirrors checkDefaultWorkspaceIdentity from the dashboard actions: when the
+// owner has exactly one workspace-shared identity, it becomes the default.
+async function checkDefaultIdentity(ownerId: string, workspaceId: string) {
+	const shared = await db
+		.select({ id: identities.id })
+		.from(identities)
+		.where(
+			and(
+				eq(identities.sharedWithWorkspace, true),
+				eq(identities.ownerId, ownerId),
+				eq(identities.workspaceId, workspaceId),
+			),
+		);
+
+	if (shared.length === 1) {
+		await db
+			.update(workspaces)
+			.set({ defaultIdentityId: shared[0].id })
+			.where(eq(workspaces.id, workspaceId));
+	}
+}
+
+// Same queue choreography as the dashboard flow (backfillMailboxes /
+// backfillAccount): discover mailboxes first, then backfill and start IDLE.
+async function startImapBackfill(identityId: string, workspaceId: string) {
+	const { smtpQueue, smtpEvents } = await getRedis();
+
+	const discoverJob = await smtpQueue.add(
+		"imap:backfill-discover",
+		{ identityId, workspaceId },
+		{
+			jobId: `imap-backfill-discover-${identityId}`,
+			attempts: 3,
+			backoff: {
+				type: "exponential",
+				delay: 1000,
+			},
+		},
+	);
+	await discoverJob.waitUntilFinished(smtpEvents, BACKFILL_DISCOVER_TIMEOUT_MS);
+
+	await smtpQueue.add(
+		"imap:backfill-account",
+		{ identityId },
+		{
+			removeOnComplete: true,
+			removeOnFail: true,
+			jobId: `imap-backfill-account-${identityId}`,
+		},
+	);
+	await smtpQueue.add(
+		"imap:start-idle",
+		{ identityId },
+		{
+			removeOnComplete: true,
+			removeOnFail: false,
+			attempts: 3,
+			backoff: { type: "exponential", delay: 1500 },
+		},
+	);
+}
+
+export default defineEventHandler(async (event) => {
+	const { ownerId, apiKey } = await validateApiKey(event);
+	const { json } = await validateJSONBody(event);
+
+	const parsed = IdentityCreateApiSchema.safeParse(json);
+	if (!parsed.success) {
+		const issues = parsed.error.issues.map((issue) => ({
+			path: issue.path.join("."),
+			message: issue.message,
+			code: issue.code,
+		}));
+		return apiError(
+			400,
+			"INVALID_REQUEST_BODY",
+			"Invalid request body",
+			issues,
+		);
+	}
+
+	const data = parsed.data;
+	const workspaceId = apiKey.workspaceId;
+
+	const account = await validateSmtpAccountOwnership({
+		accountId: data.smtpAccountId,
+		ownerId,
+	});
+
+	const [duplicate] = await db
+		.select({ id: identities.id })
+		.from(identities)
+		.where(
+			and(
+				eq(identities.workspaceId, workspaceId),
+				eq(identities.kind, "email"),
+				eq(identities.value, data.value),
+			),
+		);
+
+	if (duplicate) {
+		return apiError(
+			409,
+			"IDENTITY_EXISTS",
+			`An email identity for ${data.value} already exists in this workspace`,
+		);
+	}
+
+	let memberIds: string[];
+	if (data.sharedWithWorkspace) {
+		const members = await db
+			.select({ userId: workspaceMembers.userId })
+			.from(workspaceMembers)
+			.where(eq(workspaceMembers.workspaceId, workspaceId));
+		memberIds = members.map((m) => m.userId);
+	} else if (data.memberIds?.length) {
+		const members = await db
+			.select({ userId: workspaceMembers.userId })
+			.from(workspaceMembers)
+			.where(
+				and(
+					eq(workspaceMembers.workspaceId, workspaceId),
+					inArray(workspaceMembers.userId, data.memberIds),
+				),
+			);
+		memberIds = members.map((m) => m.userId);
+
+		if (memberIds.length !== data.memberIds.length) {
+			return apiError(
+				400,
+				"INVALID_MEMBER_IDS",
+				"One or more memberIds are not members of this workspace",
+			);
+		}
+	} else {
+		memberIds = [ownerId];
+	}
+
+	const [identity] = await db
+		.insert(identities)
+		.values({
+			ownerId,
+			workspaceId,
+			kind: "email",
+			value: data.value,
+			displayName: data.displayName ?? null,
+			smtpAccountId: account.id,
+			sharedWithWorkspace: data.sharedWithWorkspace,
+			metaData: {
+				dailyQuota: data.dailyQuota ?? defaultImapQuota,
+				sharedWithWorkspace: data.sharedWithWorkspace,
+			},
+		})
+		.returning();
+
+	await grantIdentityMembers(identity, memberIds);
+	await checkDefaultIdentity(ownerId, workspaceId);
+
+	// Mailbox sync only makes sense when the account has IMAP settings;
+	// send-only SMTP accounts skip the backfill entirely.
+	const secret = await getSmtpAccountSecret({ accountId: account.id, ownerId });
+	let backfill: "completed" | "skipped" | "failed" = "skipped";
+
+	if (secret?.config?.IMAP_HOST) {
+		try {
+			await startImapBackfill(identity.id, workspaceId);
+			backfill = "completed";
+		} catch (err) {
+			console.error(
+				`[API] IMAP backfill failed for identity ${identity.id}:`,
+				err,
+			);
+			backfill = "failed";
+		}
+	}
+
+	return apiSuccess({ identity, backfill });
+});

--- a/apps/worker/server/routes/api/kurrier/smtp-accounts/[id].delete.ts
+++ b/apps/worker/server/routes/api/kurrier/smtp-accounts/[id].delete.ts
@@ -1,0 +1,56 @@
+import {
+	db,
+	deleteSecretAdmin,
+	identities,
+	smtpAccountSecrets,
+	smtpAccounts,
+} from "@db";
+import { eq } from "drizzle-orm";
+import { defineEventHandler, getRouterParam } from "h3";
+import {
+	apiError,
+	apiSuccess,
+	validateApiKey,
+} from "../../../../../lib/api-helpers";
+import { validateSmtpAccountOwnership } from "../../../../../lib/smtp-account-helpers";
+
+export default defineEventHandler(async (event) => {
+	const { ownerId } = await validateApiKey(event);
+	const id = getRouterParam(event, "id");
+
+	if (!id) {
+		return apiError(400, "INVALID_ACCOUNT_ID", "SMTP account id is required");
+	}
+
+	const account = await validateSmtpAccountOwnership({
+		accountId: String(id),
+		ownerId,
+	});
+
+	const linkedIdentities = await db
+		.select({ id: identities.id, value: identities.value })
+		.from(identities)
+		.where(eq(identities.smtpAccountId, account.id));
+
+	if (linkedIdentities.length > 0) {
+		return apiError(
+			409,
+			"ACCOUNT_IN_USE",
+			"SMTP account is referenced by one or more identities; delete them first",
+			linkedIdentities,
+		);
+	}
+
+	const [accountSecret] = await db
+		.select()
+		.from(smtpAccountSecrets)
+		.where(eq(smtpAccountSecrets.accountId, account.id));
+
+	if (accountSecret) {
+		await deleteSecretAdmin(accountSecret.secretId);
+	}
+
+	await db.delete(smtpAccounts).where(eq(smtpAccounts.id, account.id));
+
+	return apiSuccess({ id: account.id, deleted: true });
+});

--- a/apps/worker/server/routes/api/kurrier/smtp-accounts/[id].get.ts
+++ b/apps/worker/server/routes/api/kurrier/smtp-accounts/[id].get.ts
@@ -1,0 +1,29 @@
+import { defineEventHandler, getRouterParam } from "h3";
+import {
+	apiError,
+	apiSuccess,
+	validateApiKey,
+} from "../../../../../lib/api-helpers";
+import {
+	getSmtpAccountSecret,
+	serializeSmtpAccount,
+	validateSmtpAccountOwnership,
+} from "../../../../../lib/smtp-account-helpers";
+
+export default defineEventHandler(async (event) => {
+	const { ownerId } = await validateApiKey(event);
+	const id = getRouterParam(event, "id");
+
+	if (!id) {
+		return apiError(400, "INVALID_ACCOUNT_ID", "SMTP account id is required");
+	}
+
+	const account = await validateSmtpAccountOwnership({
+		accountId: String(id),
+		ownerId,
+	});
+
+	const secret = await getSmtpAccountSecret({ accountId: account.id, ownerId });
+
+	return apiSuccess(serializeSmtpAccount(account, secret?.config ?? null));
+});

--- a/apps/worker/server/routes/api/kurrier/smtp-accounts/[id].patch.ts
+++ b/apps/worker/server/routes/api/kurrier/smtp-accounts/[id].patch.ts
@@ -1,0 +1,85 @@
+import crypto from "node:crypto";
+import {
+	createSecretAdmin,
+	db,
+	smtpAccountSecrets,
+	smtpAccounts,
+	updateSecretAdmin,
+} from "@db";
+import { SmtpAccountUpdateSchema } from "@schema";
+import { eq } from "drizzle-orm";
+import { defineEventHandler, getRouterParam } from "h3";
+import {
+	apiError,
+	apiSuccess,
+	validateApiKey,
+	validateJSONBody,
+} from "../../../../../lib/api-helpers";
+import {
+	applySmtpConfigUpdate,
+	getSmtpAccountSecret,
+	serializeSmtpAccount,
+	validateSmtpAccountOwnership,
+} from "../../../../../lib/smtp-account-helpers";
+
+export default defineEventHandler(async (event) => {
+	const { ownerId, apiKey } = await validateApiKey(event);
+	const id = getRouterParam(event, "id");
+
+	if (!id) {
+		return apiError(400, "INVALID_ACCOUNT_ID", "SMTP account id is required");
+	}
+
+	const account = await validateSmtpAccountOwnership({
+		accountId: String(id),
+		ownerId,
+	});
+
+	const { json } = await validateJSONBody(event);
+	const parsed = SmtpAccountUpdateSchema.safeParse(json);
+	if (!parsed.success) {
+		const issues = parsed.error.issues.map((issue) => ({
+			path: issue.path.join("."),
+			message: issue.message,
+			code: issue.code,
+		}));
+		return apiError(
+			400,
+			"INVALID_REQUEST_BODY",
+			"Invalid request body",
+			issues,
+		);
+	}
+
+	const secret = await getSmtpAccountSecret({ accountId: account.id, ownerId });
+
+	const config = applySmtpConfigUpdate(secret?.config ?? {}, parsed.data);
+
+	if (secret) {
+		await updateSecretAdmin(secret.secretId, {
+			value: JSON.stringify(config),
+		});
+	} else {
+		// Account rows without a linked secret can exist; heal them here.
+		config.ulid = config.ulid ?? crypto.randomUUID();
+		const created = await createSecretAdmin({
+			ownerId,
+			workspaceId: apiKey.workspaceId,
+			name: config.ulid,
+			value: JSON.stringify(config),
+		});
+		await db.insert(smtpAccountSecrets).values({
+			accountId: account.id,
+			secretId: created.id,
+			workspaceId: apiKey.workspaceId,
+		});
+	}
+
+	const [updated] = await db
+		.update(smtpAccounts)
+		.set({ updatedAt: new Date() })
+		.where(eq(smtpAccounts.id, account.id))
+		.returning();
+
+	return apiSuccess(serializeSmtpAccount(updated, config));
+});

--- a/apps/worker/server/routes/api/kurrier/smtp-accounts/index.get.ts
+++ b/apps/worker/server/routes/api/kurrier/smtp-accounts/index.get.ts
@@ -1,0 +1,29 @@
+import { db, smtpAccounts } from "@db";
+import { eq } from "drizzle-orm";
+import { defineEventHandler } from "h3";
+import { apiSuccess, validateApiKey } from "../../../../../lib/api-helpers";
+import {
+	getSmtpAccountSecret,
+	serializeSmtpAccount,
+} from "../../../../../lib/smtp-account-helpers";
+
+export default defineEventHandler(async (event) => {
+	const { ownerId } = await validateApiKey(event);
+
+	const accounts = await db
+		.select()
+		.from(smtpAccounts)
+		.where(eq(smtpAccounts.ownerId, ownerId));
+
+	const result = await Promise.all(
+		accounts.map(async (account) => {
+			const secret = await getSmtpAccountSecret({
+				accountId: account.id,
+				ownerId,
+			});
+			return serializeSmtpAccount(account, secret?.config ?? null);
+		}),
+	);
+
+	return apiSuccess(result);
+});

--- a/apps/worker/server/routes/api/kurrier/smtp-accounts/index.post.ts
+++ b/apps/worker/server/routes/api/kurrier/smtp-accounts/index.post.ts
@@ -1,0 +1,56 @@
+import { createSecretAdmin, db, smtpAccountSecrets, smtpAccounts } from "@db";
+import { SmtpAccountCreateSchema } from "@schema";
+import { defineEventHandler } from "h3";
+import {
+	apiError,
+	apiSuccess,
+	validateApiKey,
+	validateJSONBody,
+} from "../../../../../lib/api-helpers";
+import {
+	serializeSmtpAccount,
+	smtpConfigFromInput,
+} from "../../../../../lib/smtp-account-helpers";
+
+export default defineEventHandler(async (event) => {
+	const { ownerId, apiKey } = await validateApiKey(event);
+	const { json } = await validateJSONBody(event);
+
+	const parsed = SmtpAccountCreateSchema.safeParse(json);
+	if (!parsed.success) {
+		const issues = parsed.error.issues.map((issue) => ({
+			path: issue.path.join("."),
+			message: issue.message,
+			code: issue.code,
+		}));
+		return apiError(
+			400,
+			"INVALID_REQUEST_BODY",
+			"Invalid request body",
+			issues,
+		);
+	}
+
+	const workspaceId = apiKey.workspaceId;
+	const config = smtpConfigFromInput(parsed.data);
+
+	const [account] = await db
+		.insert(smtpAccounts)
+		.values({ ownerId, workspaceId })
+		.returning();
+
+	const secret = await createSecretAdmin({
+		ownerId,
+		workspaceId,
+		name: config.ulid,
+		value: JSON.stringify(config),
+	});
+
+	await db.insert(smtpAccountSecrets).values({
+		accountId: account.id,
+		secretId: secret.id,
+		workspaceId,
+	});
+
+	return apiSuccess(serializeSmtpAccount(account, config));
+});

--- a/packages/schema/src/types/api.ts
+++ b/packages/schema/src/types/api.ts
@@ -28,3 +28,50 @@ export const EmailSendSchema = z
 	});
 
 export type EmailSendInput = z.infer<typeof EmailSendSchema>;
+
+const smtpSettingsSchema = z.object({
+	host: z.string().trim().min(1),
+	port: z.coerce.number().int().min(1).max(65535),
+	username: z.string().min(1),
+	password: z.string().min(1),
+	secure: z.boolean().optional(),
+	pool: z.boolean().optional(),
+});
+
+const imapSettingsSchema = z.object({
+	host: z.string().trim().min(1),
+	port: z.coerce.number().int().min(1).max(65535),
+	username: z.string().min(1),
+	password: z.string().min(1),
+	secure: z.boolean().optional(),
+});
+
+export const SmtpAccountCreateSchema = z.object({
+	label: z.string().trim().min(1),
+	smtp: smtpSettingsSchema,
+	// Optional: only needed to receive/sync messages over IMAP
+	imap: imapSettingsSchema.optional(),
+});
+
+export type SmtpAccountCreateInput = z.infer<typeof SmtpAccountCreateSchema>;
+
+export const SmtpAccountUpdateSchema = z.object({
+	label: z.string().trim().min(1).optional(),
+	smtp: smtpSettingsSchema.partial().optional(),
+	// Pass null to remove the IMAP settings entirely
+	imap: imapSettingsSchema.partial().nullable().optional(),
+});
+
+export type SmtpAccountUpdateInput = z.infer<typeof SmtpAccountUpdateSchema>;
+
+export const IdentityCreateApiSchema = z.object({
+	value: emailAddress,
+	displayName: z.string().trim().min(1).optional(),
+	smtpAccountId: z.string().min(1),
+	sharedWithWorkspace: z.boolean().optional().default(false),
+	// Workspace member user ids to grant access to; defaults to the key owner
+	memberIds: z.array(z.string().min(1)).optional(),
+	dailyQuota: z.coerce.number().int().positive().optional(),
+});
+
+export type IdentityCreateApiInput = z.infer<typeof IdentityCreateApiSchema>;


### PR DESCRIPTION
Part of #498 (first of two stacked PRs; the admin-key PR builds on this one).

Everything needed to wire up a mailbox now exists as management API routes on the worker, so provisioning can be automated instead of clicked through the dashboard.

## Endpoints

| Route | Purpose |
|---|---|
| `POST /api/kurrier/smtp-accounts` | Create an SMTP/IMAP account (`label`, `smtp{host,port,username,password,secure,pool}`, optional `imap{...}`) |
| `GET /api/kurrier/smtp-accounts` | List own accounts (passwords never returned) |
| `GET /api/kurrier/smtp-accounts/{id}` | Fetch one |
| `PATCH /api/kurrier/smtp-accounts/{id}` | Partial update — omitted fields (incl. passwords) keep their values → password rotation; `"imap": null` removes IMAP settings |
| `DELETE /api/kurrier/smtp-accounts/{id}` | Delete account + encrypted credentials; **409** with the offending list while identities still reference it |
| `POST /api/kurrier/identities` | Email identity backed by an SMTP account: member grants (`sharedWithWorkspace`/`memberIds`), default-identity logic mirroring the dashboard, then the same discover → backfill → IDLE queue choreography; response reports `backfill: completed/skipped/failed` |

Same auth model as the existing routes (`validateApiKey`, owner-scoped). Request schemas live in `@schema` next to `EmailSendSchema`.

## Design notes

- Secrets are stored with the **same env-style keys and vault encryption the dashboard form produces** — API- and UI-created accounts are interchangeable, and the worker's IMAP client reads both identically.
- Passwords are **write-only**: responses only carry connection metadata.
- `POST /identities` waits for IMAP mailbox discovery (bounded) and reports the outcome instead of failing the identity creation — the identity exists either way, so the caller can fix credentials and re-sync.
- `PATCH` self-heals account rows that lost their secret link (see #500 — the dashboard path currently can't).
- Duplicate email identity in a workspace → clean **409** instead of a DB error.

## Docs

New `smtp-accounts` API page + `POST /identities` section on the identities page.

## Testing

Running in production on a self-hosted instance: create/list/patch/delete against a real IMAP/SMTP host (OVH), including a full mailbox onboarding with backfill + live IDLE sync, and password rotation driven by a secrets manager. `tsc --noEmit` and `nitro build` clean.
