### PR TITLE
Add instance-level admin API key for user pre-provisioning

### DIFF
--- a/apps/docs/content/docs/api/api-routes/identities.mdx
+++ b/apps/docs/content/docs/api/api-routes/identities.mdx
@@ -55,6 +55,7 @@ identity from the dashboard.
 | **sharedWithWorkspace** *(optional)* | Share the identity with all workspace members. Defaults to `false`. |
 | **memberIds** *(optional)* | Workspace member user ids granted access. Defaults to the key owner. Ignored when `sharedWithWorkspace` is `true`. |
 | **dailyQuota** *(optional)* | Daily sending quota. Defaults to the standard IMAP quota. |
+| **userEmail** *(optional)* | [Admin API key](/docs/api/authentication) only: create the identity on behalf of this user. |
 
 The response contains the created identity plus a `backfill` field:
 

--- a/apps/docs/content/docs/api/api-routes/meta.json
+++ b/apps/docs/content/docs/api/api-routes/meta.json
@@ -1,5 +1,5 @@
 {
 	"title": "Routes",
 	"defaultOpen": true,
-	"pages": ["me", "email", "webhooks", "identities", "smtp-accounts"]
+	"pages": ["me", "email", "webhooks", "identities", "smtp-accounts", "users"]
 }

--- a/apps/docs/content/docs/api/api-routes/smtp-accounts.mdx
+++ b/apps/docs/content/docs/api/api-routes/smtp-accounts.mdx
@@ -51,6 +51,7 @@ For authentication, see the [authentication guide](/docs/api/authentication).
 | **label** *(required)* | Free-form name shown in the dashboard. |
 | **smtp** *(required)* | Outgoing mail settings: `host`, `port`, `username`, `password`, plus optional `secure` (implicit TLS, e.g. port 465 — leave unset/false for STARTTLS on 587) and `pool`. |
 | **imap** *(optional)* | Incoming mail settings: `host`, `port`, `username`, `password`, optional `secure` (defaults to true). Only needed if you want to receive/sync messages. |
+| **userEmail** *(optional)* | [Admin API key](/docs/api/authentication) only: create the account on behalf of this user. `GET /smtp-accounts` accepts the same value as a `?userEmail=` query parameter. |
 
 Passwords are **never returned** by the API — responses only carry connection
 metadata:

--- a/apps/docs/content/docs/api/api-routes/users.mdx
+++ b/apps/docs/content/docs/api/api-routes/users.mdx
@@ -1,0 +1,95 @@
+---
+title: Users
+description: Pre-provision Kurrier users through the admin API
+---
+
+These endpoints let an **administrator** create user accounts ahead of time —
+so a mailbox can be fully wired up **before the person ever logs in**. Combined
+with [SMTP accounts](/docs/api/api-routes/smtp-accounts) and
+[identities](/docs/api/api-routes/identities), this enables fully automated
+onboarding: when the user signs in later (e.g. through
+[OIDC/SSO](/docs/oidc), which attaches to the existing account by email),
+their mail is already there.
+
+All routes below are relative to:
+
+```text
+https://your-domain.com/api/kurrier
+```
+
+⚠️ These endpoints require the **instance-level admin API key** — see the
+[authentication guide](/docs/api/authentication). Regular API keys are
+rejected.
+
+---
+
+## Create a user
+
+### `POST /users`
+
+```json
+{
+	"email": "user@example.com",
+	"workspaceName": "Family"
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| **email** *(required)* | Email address of the user. Must match the email their SSO/OIDC provider reports so the account links up at first login. |
+| **workspaceName** *(optional)* | Name of the default workspace. Defaults to `"Default Workspace"`. |
+
+Creates the user, their default workspace, and the owner membership, then
+queues the same provider-sync and migration jobs as a regular signup. The
+account has a random unusable password — it can only be accessed through
+SSO/OIDC login (or a password reset, where enabled).
+
+The endpoint is **idempotent on email**: if the user already exists, it
+returns them with `"created": false` instead of failing.
+
+```json
+{
+	"success": true,
+	"data": {
+		"user": { "id": "7f3b1a84-…", "email": "user@example.com" },
+		"workspace": { "id": "0d63d43a-…", "publicId": "9ANdDSgvj5" },
+		"created": true
+	}
+}
+```
+
+---
+
+## Provisioning a mailbox end to end
+
+```bash
+# 1. Create the user (before their first login)
+curl -X POST https://mail.example.com/api/kurrier/users \
+  -H "Authorization: Bearer $API_ADMIN_KEY" \
+  -d '{"email": "alice@example.com"}'
+
+# 2. Create their SMTP/IMAP account
+curl -X POST https://mail.example.com/api/kurrier/smtp-accounts \
+  -H "Authorization: Bearer $API_ADMIN_KEY" \
+  -d '{
+    "userEmail": "alice@example.com",
+    "label": "Alice mailbox",
+    "smtp": {"host": "smtp.example.com", "port": 465, "secure": true,
+             "username": "alice@example.com", "password": "…"},
+    "imap": {"host": "imap.example.com", "port": 993, "secure": true,
+             "username": "alice@example.com", "password": "…"}
+  }'
+
+# 3. Create the email identity (starts mailbox discovery + sync)
+curl -X POST https://mail.example.com/api/kurrier/identities \
+  -H "Authorization: Bearer $API_ADMIN_KEY" \
+  -d '{
+    "userEmail": "alice@example.com",
+    "value": "alice@example.com",
+    "smtpAccountId": "<id from step 2>",
+    "sharedWithWorkspace": true
+  }'
+```
+
+When Alice signs in through SSO for the first time, her mailbox is already
+synced and waiting.

--- a/apps/docs/content/docs/api/authentication.mdx
+++ b/apps/docs/content/docs/api/authentication.mdx
@@ -34,3 +34,32 @@ Every request must include your API key. Kurrier supports bearer token authentic
 ```http
 Authorization: Bearer YOUR_API_KEY
 ```
+
+---
+
+## Admin API key (instance-level)
+
+Regular API keys always act as the user who created them. For **infrastructure
+automation** — onboarding users before their first login, provisioning mail
+accounts in bulk, rotating credentials from a secrets manager — Kurrier
+supports an optional **instance-level admin key**, configured through the
+environment (worker service):
+
+```env
+API_ADMIN_KEY=some-long-random-value   # 32+ characters required
+```
+
+The feature is **opt-in**: when the variable is unset (the default), nothing
+changes and only regular API keys work.
+
+Requests bearing the admin key can act **on behalf of any user**:
+
+- [`POST /users`](/docs/api/api-routes/users) — pre-provision a user account
+  (admin key only)
+- `POST /smtp-accounts` and `POST /identities` accept a `userEmail` field
+- `GET /smtp-accounts` accepts a `?userEmail=` query parameter
+- `GET/PATCH/DELETE /smtp-accounts/{id}` resolve any account by id
+
+Treat this key like a root credential: generate it with
+`openssl rand -hex 32`, store it in your secrets manager, and never expose it
+to end users.

--- a/apps/worker/lib/api-helpers.ts
+++ b/apps/worker/lib/api-helpers.ts
@@ -1,7 +1,15 @@
-import { H3Event, createError, readRawBody } from "h3";
-import {db, apiKeys, secretsMeta, getSecretAdmin, identities} from "@db";
-import { eq, and } from "drizzle-orm";
 import crypto from "node:crypto";
+import {
+	apiKeys,
+	db,
+	getSecretAdmin,
+	identities,
+	secretsMeta,
+	users,
+	workspaces,
+} from "@db";
+import { and, eq } from "drizzle-orm";
+import { createError, type H3Event, readRawBody } from "h3";
 
 export function apiSuccess(data: any = null) {
 	return {
@@ -44,7 +52,6 @@ export async function validateJSONBody(event: H3Event) {
 
 	return { raw, json };
 }
-
 
 function safeEqual(a: string, b: string) {
 	const ab = Buffer.from(a);
@@ -134,12 +141,104 @@ export async function validateApiKey(event: H3Event) {
 	};
 }
 
+/**
+ * Instance-level admin authentication for the management API.
+ *
+ * When the API_ADMIN_KEY environment variable is set (32+ chars), requests
+ * bearing it may act on behalf of any user — e.g. to provision accounts
+ * before their first login. Opt-in: without the env var this always
+ * returns false and only regular per-user API keys work.
+ */
+export function isAdminApiRequest(event: H3Event): boolean {
+	const adminKey = process.env.API_ADMIN_KEY;
+	if (!adminKey || adminKey.length < 32) return false;
+
+	const auth = event.node.req.headers.authorization;
+	if (!auth || !auth.startsWith("Bearer ")) return false;
+
+	const token = auth.replace("Bearer ", "").trim();
+	return safeEqual(token, adminKey);
+}
+
+export function requireAdminApiKey(event: H3Event) {
+	if (!isAdminApiRequest(event)) {
+		throw createError({
+			statusCode: 401,
+			statusMessage: "This endpoint requires the admin API key",
+		});
+	}
+}
+
+export type ApiActor = {
+	ownerId: string;
+	workspaceId: string;
+	isAdmin: boolean;
+};
+
+/**
+ * Resolves who a management API request acts as.
+ *
+ * - Regular API key: the key's owner and workspace (userEmail is rejected).
+ * - Admin API key: the user designated by userEmail and the workspace they
+ *   own, so one infrastructure-held key can manage every account.
+ */
+export async function resolveApiActor(
+	event: H3Event,
+	userEmail?: string | null,
+): Promise<ApiActor> {
+	if (isAdminApiRequest(event)) {
+		if (!userEmail) {
+			throw createError({
+				statusCode: 400,
+				statusMessage:
+					"userEmail is required when authenticating with the admin API key",
+			});
+		}
+
+		const [user] = await db
+			.select()
+			.from(users)
+			.where(eq(users.email, userEmail))
+			.limit(1);
+
+		if (!user) {
+			throw createError({
+				statusCode: 404,
+				statusMessage: "User not found",
+			});
+		}
+
+		const [workspace] = await db
+			.select()
+			.from(workspaces)
+			.where(eq(workspaces.ownerId, user.id))
+			.limit(1);
+
+		if (!workspace) {
+			throw createError({
+				statusCode: 404,
+				statusMessage: "User has no workspace",
+			});
+		}
+
+		return { ownerId: user.id, workspaceId: workspace.id, isAdmin: true };
+	}
+
+	if (userEmail) {
+		throw createError({
+			statusCode: 403,
+			statusMessage: "userEmail requires the admin API key",
+		});
+	}
+
+	const { apiKey, ownerId } = await validateApiKey(event);
+	return { ownerId, workspaceId: apiKey.workspaceId, isAdmin: false };
+}
 
 export async function validateIdentityOwnership(opts: {
 	identityId: string;
 	ownerId: string;
 }) {
-
 	const [identity] = await db
 		.select()
 		.from(identities)
@@ -158,5 +257,4 @@ export async function validateIdentityOwnership(opts: {
 		});
 	}
 	return identity;
-
 }

--- a/apps/worker/lib/smtp-account-helpers.ts
+++ b/apps/worker/lib/smtp-account-helpers.ts
@@ -121,18 +121,21 @@ export function serializeSmtpAccount(
 	};
 }
 
+// ownerId null = admin API key: no ownership filter, any account resolves.
 export async function validateSmtpAccountOwnership(opts: {
 	accountId: string;
-	ownerId: string;
+	ownerId: string | null;
 }) {
 	const [account] = await db
 		.select()
 		.from(smtpAccounts)
 		.where(
-			and(
-				eq(smtpAccounts.id, opts.accountId),
-				eq(smtpAccounts.ownerId, opts.ownerId),
-			),
+			opts.ownerId === null
+				? eq(smtpAccounts.id, opts.accountId)
+				: and(
+						eq(smtpAccounts.id, opts.accountId),
+						eq(smtpAccounts.ownerId, opts.ownerId),
+					),
 		)
 		.limit(1);
 

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -21,6 +21,7 @@
 	"dependencies": {
 		"@libsql/client": "^0.15.15",
 		"addressparser": "^1.0.1",
+		"argon2": "^0.44.0",
 		"aws-sns-validator": "^1.1.5",
 		"base64-arraybuffer": "^1.0.2",
 		"bcrypt": "^6.0.0",

--- a/apps/worker/server/routes/api/kurrier/identities/index.post.ts
+++ b/apps/worker/server/routes/api/kurrier/identities/index.post.ts
@@ -11,7 +11,7 @@ import { defineEventHandler } from "h3";
 import {
 	apiError,
 	apiSuccess,
-	validateApiKey,
+	resolveApiActor,
 	validateJSONBody,
 } from "../../../../../lib/api-helpers";
 import { getRedis } from "../../../../../lib/get-redis";
@@ -103,7 +103,6 @@ async function startImapBackfill(identityId: string, workspaceId: string) {
 }
 
 export default defineEventHandler(async (event) => {
-	const { ownerId, apiKey } = await validateApiKey(event);
 	const { json } = await validateJSONBody(event);
 
 	const parsed = IdentityCreateApiSchema.safeParse(json);
@@ -122,7 +121,7 @@ export default defineEventHandler(async (event) => {
 	}
 
 	const data = parsed.data;
-	const workspaceId = apiKey.workspaceId;
+	const { ownerId, workspaceId } = await resolveApiActor(event, data.userEmail);
 
 	const account = await validateSmtpAccountOwnership({
 		accountId: data.smtpAccountId,

--- a/apps/worker/server/routes/api/kurrier/smtp-accounts/[id].delete.ts
+++ b/apps/worker/server/routes/api/kurrier/smtp-accounts/[id].delete.ts
@@ -10,12 +10,16 @@ import { defineEventHandler, getRouterParam } from "h3";
 import {
 	apiError,
 	apiSuccess,
+	isAdminApiRequest,
 	validateApiKey,
 } from "../../../../../lib/api-helpers";
 import { validateSmtpAccountOwnership } from "../../../../../lib/smtp-account-helpers";
 
 export default defineEventHandler(async (event) => {
-	const { ownerId } = await validateApiKey(event);
+	// Admin API key: any account resolves; regular keys only delete their own.
+	const ownerId = isAdminApiRequest(event)
+		? null
+		: (await validateApiKey(event)).ownerId;
 	const id = getRouterParam(event, "id");
 
 	if (!id) {

--- a/apps/worker/server/routes/api/kurrier/smtp-accounts/[id].get.ts
+++ b/apps/worker/server/routes/api/kurrier/smtp-accounts/[id].get.ts
@@ -2,6 +2,7 @@ import { defineEventHandler, getRouterParam } from "h3";
 import {
 	apiError,
 	apiSuccess,
+	isAdminApiRequest,
 	validateApiKey,
 } from "../../../../../lib/api-helpers";
 import {
@@ -11,7 +12,10 @@ import {
 } from "../../../../../lib/smtp-account-helpers";
 
 export default defineEventHandler(async (event) => {
-	const { ownerId } = await validateApiKey(event);
+	// Admin API key: any account resolves; regular keys only see their own.
+	const ownerId = isAdminApiRequest(event)
+		? null
+		: (await validateApiKey(event)).ownerId;
 	const id = getRouterParam(event, "id");
 
 	if (!id) {
@@ -23,7 +27,10 @@ export default defineEventHandler(async (event) => {
 		ownerId,
 	});
 
-	const secret = await getSmtpAccountSecret({ accountId: account.id, ownerId });
+	const secret = await getSmtpAccountSecret({
+		accountId: account.id,
+		ownerId: account.ownerId,
+	});
 
 	return apiSuccess(serializeSmtpAccount(account, secret?.config ?? null));
 });

--- a/apps/worker/server/routes/api/kurrier/smtp-accounts/[id].patch.ts
+++ b/apps/worker/server/routes/api/kurrier/smtp-accounts/[id].patch.ts
@@ -12,6 +12,7 @@ import { defineEventHandler, getRouterParam } from "h3";
 import {
 	apiError,
 	apiSuccess,
+	isAdminApiRequest,
 	validateApiKey,
 	validateJSONBody,
 } from "../../../../../lib/api-helpers";
@@ -23,7 +24,10 @@ import {
 } from "../../../../../lib/smtp-account-helpers";
 
 export default defineEventHandler(async (event) => {
-	const { ownerId, apiKey } = await validateApiKey(event);
+	// Admin API key: any account resolves; regular keys only patch their own.
+	const ownerId = isAdminApiRequest(event)
+		? null
+		: (await validateApiKey(event)).ownerId;
 	const id = getRouterParam(event, "id");
 
 	if (!id) {
@@ -51,7 +55,10 @@ export default defineEventHandler(async (event) => {
 		);
 	}
 
-	const secret = await getSmtpAccountSecret({ accountId: account.id, ownerId });
+	const secret = await getSmtpAccountSecret({
+		accountId: account.id,
+		ownerId: account.ownerId,
+	});
 
 	const config = applySmtpConfigUpdate(secret?.config ?? {}, parsed.data);
 
@@ -63,15 +70,15 @@ export default defineEventHandler(async (event) => {
 		// Account rows without a linked secret can exist; heal them here.
 		config.ulid = config.ulid ?? crypto.randomUUID();
 		const created = await createSecretAdmin({
-			ownerId,
-			workspaceId: apiKey.workspaceId,
+			ownerId: account.ownerId,
+			workspaceId: account.workspaceId,
 			name: config.ulid,
 			value: JSON.stringify(config),
 		});
 		await db.insert(smtpAccountSecrets).values({
 			accountId: account.id,
 			secretId: created.id,
-			workspaceId: apiKey.workspaceId,
+			workspaceId: account.workspaceId,
 		});
 	}
 

--- a/apps/worker/server/routes/api/kurrier/smtp-accounts/index.get.ts
+++ b/apps/worker/server/routes/api/kurrier/smtp-accounts/index.get.ts
@@ -1,14 +1,19 @@
 import { db, smtpAccounts } from "@db";
 import { eq } from "drizzle-orm";
-import { defineEventHandler } from "h3";
-import { apiSuccess, validateApiKey } from "../../../../../lib/api-helpers";
+import { defineEventHandler, getQuery } from "h3";
+import { apiSuccess, resolveApiActor } from "../../../../../lib/api-helpers";
 import {
 	getSmtpAccountSecret,
 	serializeSmtpAccount,
 } from "../../../../../lib/smtp-account-helpers";
 
 export default defineEventHandler(async (event) => {
-	const { ownerId } = await validateApiKey(event);
+	// Admin API key: pass ?userEmail= to list another user's accounts.
+	const userEmail = getQuery(event).userEmail;
+	const { ownerId } = await resolveApiActor(
+		event,
+		userEmail ? String(userEmail) : undefined,
+	);
 
 	const accounts = await db
 		.select()

--- a/apps/worker/server/routes/api/kurrier/smtp-accounts/index.post.ts
+++ b/apps/worker/server/routes/api/kurrier/smtp-accounts/index.post.ts
@@ -4,7 +4,7 @@ import { defineEventHandler } from "h3";
 import {
 	apiError,
 	apiSuccess,
-	validateApiKey,
+	resolveApiActor,
 	validateJSONBody,
 } from "../../../../../lib/api-helpers";
 import {
@@ -13,7 +13,6 @@ import {
 } from "../../../../../lib/smtp-account-helpers";
 
 export default defineEventHandler(async (event) => {
-	const { ownerId, apiKey } = await validateApiKey(event);
 	const { json } = await validateJSONBody(event);
 
 	const parsed = SmtpAccountCreateSchema.safeParse(json);
@@ -31,7 +30,10 @@ export default defineEventHandler(async (event) => {
 		);
 	}
 
-	const workspaceId = apiKey.workspaceId;
+	const { ownerId, workspaceId } = await resolveApiActor(
+		event,
+		parsed.data.userEmail,
+	);
 	const config = smtpConfigFromInput(parsed.data);
 
 	const [account] = await db

--- a/apps/worker/server/routes/api/kurrier/users/index.post.ts
+++ b/apps/worker/server/routes/api/kurrier/users/index.post.ts
@@ -1,0 +1,116 @@
+import crypto from "node:crypto";
+import { APP_VERSION } from "@common";
+import { db, users, workspaceMembers, workspaces } from "@db";
+import { UserCreateApiSchema } from "@schema";
+import argon2 from "argon2";
+import { eq } from "drizzle-orm";
+import { defineEventHandler } from "h3";
+import {
+	apiError,
+	apiSuccess,
+	requireAdminApiKey,
+	validateJSONBody,
+} from "../../../../../lib/api-helpers";
+import { getRedis } from "../../../../../lib/get-redis";
+
+// Pre-provisions a user before their first login (admin API key only):
+// same steps as signup/OIDC — user + default workspace + owner membership,
+// then the provider-sync and pending-migration jobs. The password hash is
+// a random UUID nobody knows, so the account is only reachable through
+// SSO/OIDC login, which attaches to the existing user by email.
+export default defineEventHandler(async (event) => {
+	requireAdminApiKey(event);
+
+	const { json } = await validateJSONBody(event);
+	const parsed = UserCreateApiSchema.safeParse(json);
+	if (!parsed.success) {
+		const issues = parsed.error.issues.map((issue) => ({
+			path: issue.path.join("."),
+			message: issue.message,
+			code: issue.code,
+		}));
+		return apiError(
+			400,
+			"INVALID_REQUEST_BODY",
+			"Invalid request body",
+			issues,
+		);
+	}
+
+	const { email, workspaceName } = parsed.data;
+
+	const [existing] = await db
+		.select()
+		.from(users)
+		.where(eq(users.email, email))
+		.limit(1);
+
+	if (existing) {
+		const [workspace] = await db
+			.select()
+			.from(workspaces)
+			.where(eq(workspaces.ownerId, existing.id))
+			.limit(1);
+
+		return apiSuccess({
+			user: { id: existing.id, email: existing.email },
+			workspace: workspace
+				? { id: workspace.id, publicId: workspace.publicId }
+				: null,
+			created: false,
+		});
+	}
+
+	const passwordHash = await argon2.hash(crypto.randomUUID());
+
+	const [user] = await db
+		.insert(users)
+		.values({ email, passwordHash })
+		.returning();
+
+	const [workspace] = await db
+		.insert(workspaces)
+		.values({
+			name: workspaceName ?? "Default Workspace",
+			ownerId: user.id,
+			storageBytesUsed: 0,
+		})
+		.returning();
+
+	await db
+		.insert(workspaceMembers)
+		.values({
+			workspaceId: workspace.id,
+			userId: user.id,
+			role: "owner",
+		})
+		.onConflictDoNothing();
+
+	const { commonWorkerQueue, migrationWorkerQueue } = await getRedis();
+
+	await commonWorkerQueue.add("sync-providers", {
+		userId: user.id,
+		workspaceId: workspace.id,
+	});
+
+	await migrationWorkerQueue.add(
+		"migration:run-for-user-after-signup",
+		{ userId: user.id, workspaceId: workspace.id, email },
+		{
+			attempts: 3,
+			backoff: {
+				type: "exponential",
+				delay: 3000,
+			},
+			removeOnComplete: { age: 60 },
+			removeOnFail: false,
+			jobId: `migration:${user.id}:${APP_VERSION}`,
+		},
+	);
+
+	return apiSuccess({
+		user: { id: user.id, email: user.email },
+		workspace: { id: workspace.id, publicId: workspace.publicId },
+		created: true,
+	});
+});

--- a/db/example.develop.env
+++ b/db/example.develop.env
@@ -63,3 +63,8 @@ OIDC_PROVIDER_NAME=
 OIDC_SCOPES=
 # Optional: token endpoint auth method, client_secret_basic (default) or client_secret_post
 OIDC_TOKEN_AUTH_METHOD=
+
+# Instance-level admin API key (worker): lets infrastructure automation act
+# on behalf of any user (pre-provision users, SMTP accounts, identities).
+# Opt-in; 32+ chars required. Generate with: openssl rand -hex 32
+API_ADMIN_KEY=

--- a/db/example.env
+++ b/db/example.env
@@ -64,3 +64,8 @@ OIDC_PROVIDER_NAME=
 OIDC_SCOPES=
 # Optional: token endpoint auth method, client_secret_basic (default) or client_secret_post
 OIDC_TOKEN_AUTH_METHOD=
+
+# Instance-level admin API key (worker): lets infrastructure automation act
+# on behalf of any user (pre-provision users, SMTP accounts, identities).
+# Opt-in; 32+ chars required. Generate with: openssl rand -hex 32
+API_ADMIN_KEY=

--- a/packages/schema/src/types/api.ts
+++ b/packages/schema/src/types/api.ts
@@ -51,6 +51,8 @@ export const SmtpAccountCreateSchema = z.object({
 	smtp: smtpSettingsSchema,
 	// Optional: only needed to receive/sync messages over IMAP
 	imap: imapSettingsSchema.optional(),
+	// Admin API key only: create the account on behalf of this user
+	userEmail: emailAddress.optional(),
 });
 
 export type SmtpAccountCreateInput = z.infer<typeof SmtpAccountCreateSchema>;
@@ -72,6 +74,15 @@ export const IdentityCreateApiSchema = z.object({
 	// Workspace member user ids to grant access to; defaults to the key owner
 	memberIds: z.array(z.string().min(1)).optional(),
 	dailyQuota: z.coerce.number().int().positive().optional(),
+	// Admin API key only: create the identity on behalf of this user
+	userEmail: emailAddress.optional(),
 });
 
 export type IdentityCreateApiInput = z.infer<typeof IdentityCreateApiSchema>;
+
+export const UserCreateApiSchema = z.object({
+	email: emailAddress,
+	workspaceName: z.string().trim().min(1).optional(),
+});
+
+export type UserCreateApiInput = z.infer<typeof UserCreateApiSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -398,6 +398,9 @@ importers:
       addressparser:
         specifier: ^1.0.1
         version: 1.0.1
+      argon2:
+        specifier: ^0.44.0
+        version: 0.44.0
       aws-sns-validator:
         specifier: ^1.1.5
         version: 1.1.5
@@ -1107,11 +1110,11 @@ packages:
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -3656,6 +3659,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -3980,6 +3984,10 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  baseline-browser-mapping@2.9.10:
+    resolution: {integrity: sha512-2VIKvDx8Z1a9rTB2eCkdPE5nSe28XnA+qivGnWHoB40hMMt/h1hSz0960Zqsn6ZyxWXUie0EBdElKv8may20AA==}
+    hasBin: true
+
   bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
 
@@ -4248,6 +4256,7 @@ packages:
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
     engines: {node: '>=12.0.0'}
+    deprecated: v4 is no longer maintained, upgrade to v5
 
   croner@9.1.0:
     resolution: {integrity: sha512-p9nwwR4qyT5W996vBZhdvBCnMhicY5ytZkR4D1Xj0wuTDEiMnjwR57Q3RXYY/s0EpX6Ay3vgIcfaR+ewGHsi+g==}
@@ -5824,7 +5833,6 @@ packages:
 
   libsql@0.5.22:
     resolution: {integrity: sha512-NscWthMQt7fpU8lqd7LXMvT9pi+KhhmTHAJWUB/Lj6MWa0MKFv0F2V4C6WKKpjCVZl0VwcDz4nOI3CyaT1DDiA==}
-    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   lightningcss-android-arm64@1.30.2:
@@ -5997,6 +6005,7 @@ packages:
 
   mailsplit@5.0.0:
     resolution: {integrity: sha512-HeXA0eyCKBtZqbr7uoeb3Nn2L7VV8Vm27x6/YBb0ZiNzRzLoNS2PqRgGYADwh0cBzLYtqddq40bSSirqLO2LGw==}
+    deprecated: This package has been renamed to @zone-eu/mailsplit. Please update your dependencies.
 
   markdown-extensions@2.0.0:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
@@ -12480,6 +12489,8 @@ snapshots:
 
   baseline-browser-mapping@2.10.32: {}
 
+  baseline-browser-mapping@2.9.10: {}
+
   bcrypt-pbkdf@1.0.2:
     dependencies:
       tweetnacl: 0.14.5
@@ -12535,7 +12546,7 @@ snapshots:
 
   browserslist@4.28.1:
     dependencies:
-      baseline-browser-mapping: 2.10.32
+      baseline-browser-mapping: 2.9.10
       caniuse-lite: 1.0.30001759
       electron-to-chromium: 1.5.267
       node-releases: 2.0.27
@@ -15478,7 +15489,7 @@ snapshots:
 
   node-abi@3.85.0:
     dependencies:
-      semver: 7.8.5
+      semver: 7.7.3
     optional: true
 
   node-abort-controller@3.1.1: {}


### PR DESCRIPTION
Closes #498. **Stacked on #502** — this branch contains its commits; only the last commit (`Add instance-level admin API key for user pre-provisioning`) is new. Review after #502, or review that commit alone.

Regular API keys always act as their owner, which makes automated onboarding impossible: someone must log in and create a key before anything can be provisioned for them (not an option when the "someone" is a family member or a fleet of users). This adds an **opt-in instance-level admin key** for infrastructure automation.

## What's in

- **`API_ADMIN_KEY`** env var on the worker. Opt-in: unset (the default) → nothing changes, only regular API keys work. Enforced ≥ 32 chars, compared with `timingSafeEqual`.
- **`POST /api/kurrier/users`** (admin key only): pre-provision a user + default workspace + owner membership, then the same provider-sync and migration jobs as a regular signup. Password hash is a random UUID nobody knows — the account is only reachable through SSO/OIDC login, which attaches to the existing user by email. **Idempotent on email** (returns `created: false`).
- **On-behalf provisioning**: `POST /smtp-accounts` and `POST /identities` accept `userEmail`; `GET /smtp-accounts` accepts `?userEmail=`; the `/smtp-accounts/{id}` routes resolve any account for the admin key. Regular keys are rejected with 403 if they try to pass `userEmail`.
- Worker gains the `argon2` dependency (same hashing as the web signup path).
- **Docs**: admin-key section in the authentication guide, new `users` API page with an end-to-end onboarding example (create user → SMTP account → identity, all before first login).

## Security notes

- The admin key never grants dashboard/session access — it only widens the management API, and only when the operator explicitly configures it.
- Admin requests must name the target user explicitly (`userEmail`); nothing is implicit.
- Documented as a root-credential-class secret (generate with `openssl rand -hex 32`, keep in a secrets manager).

## Testing

Running in production on a self-hosted instance: full family onboarding (user pre-provisioned before first SSO login, mailbox created, IMAP backfill + IDLE sync live) and password rotation driven from a secrets manager through `PATCH /smtp-accounts/{id}`. First-login SSO attaches to the pre-provisioned account as expected. `tsc --noEmit` and `nitro build` clean.
