### PR TITLE
feat: add forward action to mail rules

### DIFF
--- a/apps/worker/lib/rules/rule-items/forward-message.ts
+++ b/apps/worker/lib/rules/rule-items/forward-message.ts
@@ -1,0 +1,30 @@
+import { db, mailboxes } from "@db";
+import { and, eq } from "drizzle-orm";
+import { getRedis } from "../../get-redis";
+
+export const forwardMessage = async (
+    originalMessageId: string,
+    forwardTo: string[],
+    identityId: string,
+) => {
+    if (!forwardTo?.length || !identityId) return;
+
+    const [sentMailbox] = await db
+        .select()
+        .from(mailboxes)
+        .where(and(eq(mailboxes.identityId, identityId), eq(mailboxes.slug, "sent")));
+
+    if (!sentMailbox) return;
+
+    const { sendMailQueue } = await getRedis();
+
+    await sendMailQueue.add("send-and-reconcile", {
+        newMessageId: crypto.randomUUID(),
+        mode: "forward",
+        originalMessageId,
+        sentMailboxId: String(sentMailbox.id),
+        mailboxId: String(sentMailbox.id),
+        to: forwardTo,
+        attachments: "[]",
+    });
+};

--- a/apps/worker/lib/rules/rules-processor.ts
+++ b/apps/worker/lib/rules/rules-processor.ts
@@ -4,6 +4,8 @@ import { MailRuleMatchV1, mailRulesFieldsList, mailRulesOpsList } from "@schema"
 import { markAsRead } from "./rule-items/mark-read";
 import { toggleStar } from "./rule-items/mark-flag";
 import { moveToTrash } from "./rule-items/move-to-trash";
+import { forwardMessage } from "./rule-items/forward-message";
+
 
 type AddressValue = { address?: string | null; name?: string | null };
 type AddressObjectLike =
@@ -272,6 +274,14 @@ export const processRules = async ({ messageId }: { messageId: string }) => {
                     })
                     break;
                 }
+		case "forward": {
+    const forwardTo = (act.params as any)?.forwardTo as string[] | undefined;
+    if (!forwardTo?.length) break;
+    const forwardCount = Number((message.headersJson as any)?.["X-Kurrier-Forward-Count"]) || 0;
+    if (forwardCount >= 5) break;
+    await forwardMessage(message.id, forwardTo, identity.id);
+    break;
+}
                 default: {
                     break;
                 }

--- a/apps/worker/server/plugins/send-mail.ts
+++ b/apps/worker/server/plugins/send-mail.ts
@@ -301,6 +301,13 @@ export default defineNitroPlugin(async (nitroApp) => {
 				html,
 				ownerId: mailbox.identity.ownerId,
 				seen: true,
+				headersJson: data.mode === "forward"
+				? {
+					"X-Kurrier-Forward-Count": String(
+						(Number(origRow?.message?.headersJson?.["X-Kurrier-Forward-Count"]) || 0) + 1,
+					),
+				}
+				: undefined,
 			});
 			if (decodedForm.apiMessageId) {
 				newMessageBody.id = String(decodedForm.apiMessageId);
@@ -313,6 +320,7 @@ export default defineNitroPlugin(async (nitroApp) => {
 				html: newMessageBody.html ?? "",
 				inReplyTo: inReplyTo ?? "",
 				references: references,
+				headers: newMessageBody.headersJson ?? undefined,
 				attachments: attachmentBlobs.map((att) => ({
 					name: att.name,
 					content: att.blob,

--- a/db/init/migrations/005_migration.sql
+++ b/db/init/migrations/005_migration.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."mail_rule_action_type" ADD VALUE 'forward';--> statement-breakpoint

--- a/packages/db/src/drizzle/schema.ts
+++ b/packages/db/src/drizzle/schema.ts
@@ -1736,9 +1736,14 @@ export const mailRuleActions = pgTable(
             .notNull(),
         actionType: MailRuleActionTypeEnum("action_type").notNull(),
         order: integer("order").notNull().default(0),
-        params: jsonb("params")
-            .$type<{ labelId?: string; mailboxId?: string } | null>()
-            .default(sql`null`),
+       params: jsonb("params")
+    .$type<{
+        labelId?: string;
+        mailboxId?: string;
+        forwardTo?: string[];
+        keepOriginal?: boolean;
+    } | null>()
+    .default(sql`null`),
 		workspaceId: uuid("workspace_id")
 			.references(() => workspaces.id)
 			.notNull()

--- a/packages/providers/src/core.ts
+++ b/packages/providers/src/core.ts
@@ -137,8 +137,9 @@ export interface Mailer {
 			text: string;
 			html: string;
 			from: string;
-			inReplyTo: string;
+			inReplyTo: string; 
 			references: string[];
+			headers?: Record<string, string>;
 			attachments?: { name: string; content: Blob; contentType: string }[];
 		},
 	): Promise<{ success: boolean; MessageId?: string; error?: string }>;

--- a/packages/providers/src/mail/smtp.ts
+++ b/packages/providers/src/mail/smtp.ts
@@ -144,6 +144,7 @@ export class SmtpMailer implements Mailer {
 			from: string;
 			inReplyTo: string;
 			references: string[];
+			headers?: Record<string, string>;
 			attachments?: { name: string; content: Blob; contentType: string }[];
 		},
 	): Promise<{ success: boolean; MessageId?: string }> {
@@ -161,6 +162,7 @@ export class SmtpMailer implements Mailer {
 			if (opts.inReplyTo) headers["In-Reply-To"] = opts.inReplyTo;
 			if (opts.references?.length)
 				headers["References"] = opts.references.join(" ");
+if (opts.headers) Object.assign(headers, opts.headers);
 
 			const info = await this.transporter.sendMail({
 				from: opts.from,

--- a/packages/schema/src/types/mail-rules.ts
+++ b/packages/schema/src/types/mail-rules.ts
@@ -38,6 +38,7 @@ export const mailRulesActionsList = [
     "flag",
     "add_label",
     "trash",
+    "forward",
 ] as const;
 
 


### PR DESCRIPTION
Adds a forward action to the mail rules system, reusing the existing forward compose/send pipeline instead of building a separate one.

What's here:

New forward value on the mail rule action enum, with forwardTo (destination addresses) and keepOriginal added to the action's params
rules-processor.ts now handles case "forward", queuing the forward through the same send-mail.ts pipeline manual forwards already use — so it goes through the identity's existing SMTP/provider config, no new sending code
Attachments aren't re-uploaded — the forward reuses the original message via originalMessageId, same as the manual "Forward" button does today
Loop prevention: outgoing forwards get stamped with an X-Kurrier-Forward-Count header (incrementing on each hop), and the rules engine refuses to forward again once that count hits 5
Migration: 005_migration.sql adds the new enum value

Known gaps / follow-ups I'd want feedback on:

keepOriginal is in the schema but there's no UI wiring yet to actually trash/archive the original when it's false — right now the original is always kept. Happy to add that as a follow-up or in this PR if preferred.
The headers passthrough I added to the Mailer interface is only implemented for the SMTP provider. SES and Google providers accept the field in their type signature but don't act on it yet, so loop prevention headers won't currently travel through those providers' outgoing mail. Flagging this explicitly rather than leaving it silent.
No automated tests added yet — tested manually by running the worker locally (pnpm run dev:worker) and confirming it builds and boots cleanly with these changes.