### PR TITLE
feat: make verified_email requirement optional for generic OIDC login

### DIFF
--- a/.changeset/optional-oidc-verified-email.md
+++ b/.changeset/optional-oidc-verified-email.md
@@ -1,0 +1,5 @@
+---
+"@kurrier/repo": minor
+---
+
+Add OIDC_REQUIRE_VERIFIED_EMAIL to make the email_verified requirement optional for generic OIDC login, for IdPs that never set this claim to true.

--- a/apps/docs/content/docs/oidc.mdx
+++ b/apps/docs/content/docs/oidc.mdx
@@ -190,6 +190,7 @@ OIDC_CLIENT_SECRET=your_client_secret
 OIDC_PROVIDER_NAME=My Company SSO   # label on the login button (default: "SSO")
 OIDC_SCOPES=openid email profile    # default shown
 OIDC_TOKEN_AUTH_METHOD=client_secret_basic  # or client_secret_post
+OIDC_REQUIRE_VERIFIED_EMAIL=true    # set to "false" to accept unverified emails
 ```
 
 The generic login button appears on the login and signup pages as soon as `OIDC_ISSUER_URL`, `OIDC_CLIENT_ID` and `OIDC_CLIENT_SECRET` are all set.
@@ -214,7 +215,8 @@ https://your-domain.com/api/auth/oidc/generic/callback
 - **Token endpoint authentication** defaults to `client_secret_basic` (the OAuth 2.0 default). Some providers default to or require `client_secret_post` — set `OIDC_TOKEN_AUTH_METHOD` accordingly.
 - **Claims**: Kurrier needs the `email` and `sub` claims. If the ID token does not carry `email` (e.g. Authelia exposes profile claims only through the userinfo endpoint), Kurrier automatically falls back to the **userinfo endpoint**.
 - **Identity mapping**: returning users are identified by the stable `issuer + sub` pair stored in `auth_accounts` — never by email. A change to the email reported by the IdP does not change which Kurrier user is authenticated.
-- **User provisioning**: on the very first login, the **verified** email claim is used once, to link the external identity to an existing Kurrier user or to create a new user + default workspace. Unverified emails are rejected.
+- **User provisioning**: on the very first login, the **verified** email claim is used once, to link the external identity to an existing Kurrier user or to create a new user + default workspace. Unverified emails are rejected by default.
+- **Unverified emails**: some IdPs never set `email_verified: true` (e.g. OpenCloud's native OIDC provider). Set `OIDC_REQUIRE_VERIFIED_EMAIL=false` to accept the email claim regardless of the `email_verified` value. Leave this unset (or `true`) unless your IdP requires it — it's a deliberate security default.
 
 ### Example: Authelia
 

--- a/apps/web/app/api/auth/oidc/generic/callback/route.ts
+++ b/apps/web/app/api/auth/oidc/generic/callback/route.ts
@@ -149,9 +149,10 @@ export async function GET(request: NextRequest) {
 		 * 1. link the external identity to an existing Kurrier user, or
 		 * 2. provision a new Kurrier user.
 		 *
-		 * Don't automatically link/create from an unverified email.
+		 * Don't automatically link/create from an unverified email, unless
+		 * the operator has explicitly opted out via OIDC_REQUIRE_VERIFIED_EMAIL.
 		 */
-		if (!email || !emailVerified) {
+		if (!email || (settings.requireVerifiedEmail && !emailVerified)) {
 			return NextResponse.redirect(new URL("/auth/login", baseUrl));
 		}
 

--- a/apps/web/lib/generic-oidc.ts
+++ b/apps/web/lib/generic-oidc.ts
@@ -7,6 +7,7 @@ export type GenericOidcSettings = {
 	providerName: string;
 	scopes: string;
 	tokenAuthMethod: "client_secret_basic" | "client_secret_post";
+	requireVerifiedEmail: boolean;
 };
 
 /**
@@ -33,6 +34,10 @@ export function getGenericOidcSettings(): GenericOidcSettings | null {
 			process.env.OIDC_TOKEN_AUTH_METHOD === "client_secret_post"
 				? "client_secret_post"
 				: "client_secret_basic",
+		// Secure by default: only skip the email_verified check when the
+		// operator explicitly opts out, e.g. for IdPs that never set this
+		// claim to true (some deployments of OpenCloud's native OIDC provider).
+		requireVerifiedEmail: process.env.OIDC_REQUIRE_VERIFIED_EMAIL !== "false",
 	};
 }
 

--- a/db/example.develop.env
+++ b/db/example.develop.env
@@ -63,6 +63,9 @@ OIDC_PROVIDER_NAME=
 OIDC_SCOPES=
 # Optional: token endpoint auth method, client_secret_basic (default) or client_secret_post
 OIDC_TOKEN_AUTH_METHOD=
+# Optional: set to "false" to accept unverified emails from IdPs that never
+# set email_verified to true (defaults to "true", i.e. required)
+OIDC_REQUIRE_VERIFIED_EMAIL=
 
 # Instance-level admin API key (worker): lets infrastructure automation act
 # on behalf of any user (pre-provision users, SMTP accounts, identities).

--- a/db/example.env
+++ b/db/example.env
@@ -64,6 +64,9 @@ OIDC_PROVIDER_NAME=
 OIDC_SCOPES=
 # Optional: token endpoint auth method, client_secret_basic (default) or client_secret_post
 OIDC_TOKEN_AUTH_METHOD=
+# Optional: set to "false" to accept unverified emails from IdPs that never
+# set email_verified to true (defaults to "true", i.e. required)
+OIDC_REQUIRE_VERIFIED_EMAIL=
 
 # Instance-level admin API key (worker): lets infrastructure automation act
 # on behalf of any user (pre-provision users, SMTP accounts, identities).


### PR DESCRIPTION
Fixes #512

## Summary

Adds `OIDC_REQUIRE_VERIFIED_EMAIL` (default `true`) so operators can opt out of the `email_verified` claim check on first-login account linking/creation for the generic OIDC provider. Some spec-compliant IdPs (e.g. OpenCloud's native OIDC provider) never set `email_verified: true`, which currently blocks login entirely with no way to override via configuration.

## Changes

* `apps/web/lib/generic-oidc.ts`: new `requireVerifiedEmail` setting, read from `OIDC_REQUIRE_VERIFIED_EMAIL` (defaults to required, i.e. `true`, unless explicitly set to `"false"`)
* `apps/web/app/api/auth/oidc/generic/callback/route.ts`: only enforces the `emailVerified` check when `requireVerifiedEmail` is true
* Documented the new variable in `apps/docs/content/docs/oidc.mdx` and both example env files
* Changeset included

## Notes

* Default behavior is unchanged (secure by default) — this is opt-in only
* No change to returning-user lookup (still `issuer + sub`, never email)
* Ran `pnpm biome check` on the touched files; `generic-oidc.ts` is fully clean, the callback route's pre-existing lint findings (non-null assertion, import ordering) predate this change and are unrelated to it