### PR TITLE
feat: allow disabling local (email/password) login

### DIFF
--- a/.changeset/disable-local-login.md
+++ b/.changeset/disable-local-login.md
@@ -1,0 +1,5 @@
+---
+"@kurrier/repo": minor
+---
+
+Add DISABLE_LOCAL_LOGIN to allow disabling email/password login for SSO-only deployments.

--- a/apps/web/app/[locale]/auth/login/page.tsx
+++ b/apps/web/app/[locale]/auth/login/page.tsx
@@ -4,6 +4,7 @@ import KurrierLogo from "@/components/common/kurrier-logo";
 import * as React from "react";
 import {getDictionary, Locale} from "@/lib/dictionaries";
 import { getGenericOidcSettings } from "@/lib/generic-oidc";
+import { getPublicEnv } from "@schema";
 
 export default async function LoginPage({ params, searchParams }: {
 	params: Promise<{ locale: Locale }>;
@@ -16,6 +17,7 @@ export default async function LoginPage({ params, searchParams }: {
 	const showSignupDisabledMessage = sParams.message === "signup_disabled";
 	const googleEnabled = process.env.OIDC_GOOGLE_CLIENT_ID && process.env.OIDC_GOOGLE_CLIENT_SECRET;
 	const genericOidc = getGenericOidcSettings();
+	const { DISABLE_LOCAL_LOGIN } = getPublicEnv();
 
 
 	return (
@@ -36,7 +38,7 @@ export default async function LoginPage({ params, searchParams }: {
 						</p>
 					</div>
 				)}
-				<LoginForm dict={dict} oidc={{
+				<LoginForm dict={dict} disableLocalLogin={DISABLE_LOCAL_LOGIN} oidc={{
 					googleEnabled: !!googleEnabled,
 					genericEnabled: !!genericOidc,
 					genericName: genericOidc?.providerName,

--- a/apps/web/components/auth/login-form.tsx
+++ b/apps/web/components/auth/login-form.tsx
@@ -25,12 +25,13 @@ export function LoginForm({
 	className,
 	oidc,
 	dict,
+	disableLocalLogin,
 	...props
 }: React.ComponentProps<"div"> & {oidc?: {
 		googleEnabled?: boolean;
 		genericEnabled?: boolean;
 		genericName?: string;
-	} }  & {dict: Dictionary}) {
+	} }  & {dict: Dictionary} & {disableLocalLogin?: boolean}) {
 	const [formState, formAction, isPending] = useActionState<
 		FormState,
 		FormData
@@ -54,11 +55,15 @@ export function LoginForm({
 							Login with {oidc?.genericName || "SSO"}
 						</Button>
 					)}
-					{!oidc?.googleEnabled && !oidc?.genericEnabled && (
+					{!oidc?.googleEnabled && !oidc?.genericEnabled && disableLocalLogin && (
+						<div className={'text-sm text-center'}>No login methods are currently enabled. Please contact your administrator.</div>
+					)}
+					{!oidc?.googleEnabled && !oidc?.genericEnabled && !disableLocalLogin && (
 						<div className={'text-sm text-center'}>No third-party authentication methods are currently enabled.</div>
 					)}
 				</CardHeader>
 
+				{!disableLocalLogin && (
 				<CardContent>
 					<Form action={formAction}>
 						<input type="hidden" name="locale" value={dict.locale} />
@@ -150,6 +155,7 @@ export function LoginForm({
 						</div>
 					</Form>
 				</CardContent>
+				)}
 			</Card>
 
 			{/*<div className="text-muted-foreground *:[a]:hover:text-primary text-center text-xs text-balance *:[a]:underline *:[a]:underline-offset-4">*/}

--- a/apps/web/lib/actions/auth.ts
+++ b/apps/web/lib/actions/auth.ts
@@ -141,6 +141,15 @@ export async function login(
 	_prev: FormState,
 	formData: FormData,
 ): Promise<FormState> {
+	const { DISABLE_LOCAL_LOGIN } = getPublicEnv();
+
+	if (DISABLE_LOCAL_LOGIN) {
+		return {
+			success: false,
+			error: "Local login is currently disabled. Please use SSO to sign in.",
+		};
+	}
+
 	const { email, password, locale } = decode(formData) as {
 		email: string;
 		password: string;

--- a/packages/schema/src/types/config.ts
+++ b/packages/schema/src/types/config.ts
@@ -38,6 +38,7 @@ export const ZPublicConfig = z.object({
 	DOCS_URL: z.string().optional(),
 	DAV_URL: z.string("DAV_URL must be present"),
 	DISABLE_SIGNUP: z.string().optional().transform((val) => val === "true").default(false),
+	DISABLE_LOCAL_LOGIN: z.string().optional().transform((val) => val === "true").default(false),
 });
 
 export type ServerConfig = z.infer<typeof ZServerConfig>;


### PR DESCRIPTION
Fixes #513

## Summary

Adds `DISABLE_LOCAL_LOGIN`, following the same pattern as the existing `DISABLE_SIGNUP`, so SSO-only deployments can turn off the email/password login form and reject local login attempts server-side.

## Changes

* `packages/schema/src/types/config.ts`: new `DISABLE_LOCAL_LOGIN` field on `ZPublicConfig`
* `apps/web/lib/actions/auth.ts`: `login()` rejects with an explicit error when the flag is set, before touching the database
* `apps/web/components/auth/login-form.tsx`: hides the email/password fields (and the signup link) when the flag is set, leaving only configured OIDC button(s); adjusts the empty-state message when no login method at all is configured
* `apps/web/app/[locale]/auth/login/page.tsx`: passes the flag down to `LoginForm`

## Notes

* Server-side enforcement is independent of the UI hide — calling the `login` action directly still fails when the flag is set
* No effect on `DISABLE_SIGNUP`/signup behavior (separate, independent flag)
* Not documented in example env files, matching the existing convention for `DISABLE_SIGNUP` (also undocumented there)
* Ran `pnpm biome check` on the touched files; all findings are pre-existing in these files and unrelated to this change