### PR TITLE
fix: workspace overview stats stuck at 0 due to owner role typo

### DIFF
--- a/.changeset/fix-owner-role-typo.md
+++ b/.changeset/fix-owner-role-typo.md
@@ -1,0 +1,5 @@
+---
+"@kurrier/repo": patch
+---
+
+Fix workspace overview always showing 0 for Connected Providers, Active Identities, Verified Domains and Volumes due to an "owners"/"owner" string mismatch when checking the workspace role.

--- a/apps/web/lib/actions/dashboard.ts
+++ b/apps/web/lib/actions/dashboard.ts
@@ -1139,7 +1139,7 @@ export const getDashboardStats = async () => {
 	return handleAction(async () => {
 		const rls = await rlsClient();
 		const workspaceRole = await getWorkspaceRole();
-		const isOwner = workspaceRole === "owners";
+		const isOwner = workspaceRole === "owner";
 
 		const data = await rls(async (tx) => {
 			const [


### PR DESCRIPTION
Fixes #516

## Summary

One-character fix. `getDashboardStats()` (`apps/web/lib/actions/dashboard.ts`) checked `workspaceRole === "owners"` (plural), but the actual `workspace_role` Postgres enum (`packages/db/src/drizzle/schema.ts`) only has `["owner", "admin", "member"]` — singular. Every other call site in the app already checks the singular form correctly (e.g. the overview page itself).

Because the comparison never matched, `isOwner` was always `false` for real workspace owners, which skipped the whole block that computes `connectedProviders`, `activeIdentities`, `verifiedDomains`, `volumeCount` and `driveEntryCount` — all silently stayed `null` and rendered as `0` in the Workspace overview page, including the "Setup progress" checklist staying permanently unchecked.

## Change

```diff
- const isOwner = workspaceRole === "owners";
+ const isOwner = workspaceRole === "owner";
```

Display-only bug — provider/identity records themselves were never affected.

## Notes

Ran `pnpm biome check` on the touched file; no findings on the changed line (the file has pre-existing, unrelated `noExplicitAny` warnings elsewhere that predate this change).