### PR TITLE
fix: clicking sidebar folder while a thread is open now closes it

### DIFF
--- a/.changeset/fix-thread-nav-stale-slot.md
+++ b/.changeset/fix-thread-nav-stale-slot.md
@@ -1,0 +1,5 @@
+---
+"@kurrier/repo": patch
+---
+
+Fix mailbox thread view staying open after clicking a folder in the sidebar while a thread is open, caused by the intercepted @thread parallel-route slot not resetting on soft navigation. Clicking a folder now forces a real navigation when a thread is currently open.

--- a/.changeset/fix-thread-nav-stale-slot.md
+++ b/.changeset/fix-thread-nav-stale-slot.md
@@ -2,4 +2,4 @@
 "@kurrier/repo": patch
 ---
 
-Fix mailbox thread view staying open after clicking a folder in the sidebar while a thread is open, caused by the intercepted @thread parallel-route slot not resetting on soft navigation. Clicking a folder now forces a real navigation when a thread is currently open.
+Fix mailbox thread view staying open after clicking a folder in the sidebar while a thread is open, caused by the intercepted @thread parallel-route slot not resetting on soft navigation. The slot is now keyed by the current pathname so it unmounts (and re-resolves against @thread/default.tsx) whenever the URL changes, instead of relying on a manual router.push()/router.refresh() workaround that didn't reliably clear it.

--- a/apps/web/app/[locale]/w/[wPublicId]/dashboard/(unified)/(mail)/mail/[identityPublicId]/[mailboxSlug]/layout.tsx
+++ b/apps/web/app/[locale]/w/[wPublicId]/dashboard/(unified)/(mail)/mail/[identityPublicId]/[mailboxSlug]/layout.tsx
@@ -1,4 +1,5 @@
-import React, { ReactNode } from "react";
+import React, { type ReactNode } from "react";
+import ThreadSlotReset from "@/components/mailbox/default/thread-slot-reset";
 import MailboxSearchHeader from "@/components/mailbox/mailbox-search-header";
 
 type LayoutProps = {
@@ -15,14 +16,11 @@ export default async function DashboardLayout({
 	thread,
 	params,
 }: LayoutProps) {
-
-
-
 	return (
 		<>
-            <MailboxSearchHeader params={params} />
+			<MailboxSearchHeader params={params} />
 
-			{thread}
+			<ThreadSlotReset>{thread}</ThreadSlotReset>
 			{children}
 		</>
 	);

--- a/apps/web/components/dashboard/identity-mailboxes-list.tsx
+++ b/apps/web/components/dashboard/identity-mailboxes-list.tsx
@@ -1,38 +1,38 @@
 "use client";
 
-import Link from "next/link";
-import { useParams, usePathname, useRouter } from "next/navigation";
-import { cn, setSidebarWidth } from "@/lib/utils";
-import {
-	Inbox,
-	Send,
-	FileText,
-	Archive,
-	Ban,
-	Trash2,
-	Folder,
-	ChevronRight,
-	ChevronDown,
-	MoreVertical,
-	Clock4,
-} from "lucide-react";
-import * as React from "react";
-import { Suspense, use, useEffect } from "react";
-import {
-	FetchIdentityMailboxListResult,
-	FetchMailboxUnreadCountsResult,
-} from "@/lib/actions/mailbox";
-import { MailboxKind } from "@schema";
-import {
+import type {
 	DraftMessageEntity,
 	IdentityEntity,
 	MailboxEntity,
 	MailboxThreadEntity,
 } from "@db";
-import AddNewFolder from "@/components/mailbox/default/add-new-folder";
 import { Menu, Select } from "@mantine/core";
-import DeleteMailboxFolder from "@/components/mailbox/default/delete-folder";
+import type { MailboxKind } from "@schema";
 import { IconMailFast } from "@tabler/icons-react";
+import {
+	Archive,
+	Ban,
+	ChevronDown,
+	ChevronRight,
+	Clock4,
+	FileText,
+	Folder,
+	Inbox,
+	MoreVertical,
+	Send,
+	Trash2,
+} from "lucide-react";
+import Link from "next/link";
+import { useParams, usePathname, useRouter } from "next/navigation";
+import * as React from "react";
+import { Suspense, use, useEffect } from "react";
+import AddNewFolder from "@/components/mailbox/default/add-new-folder";
+import DeleteMailboxFolder from "@/components/mailbox/default/delete-folder";
+import type {
+	FetchIdentityMailboxListResult,
+	FetchMailboxUnreadCountsResult,
+} from "@/lib/actions/mailbox";
+import { cn, setSidebarWidth } from "@/lib/utils";
 
 const ORDER: MailboxKind[] = [
 	"inbox",
@@ -120,12 +120,12 @@ function buildTree(
 }
 
 function IdentityExtraCounts({
-								 identity,
-								 scheduledDraftsPromise,
-								 snoozedThreadsPromise,
-								 workspacePublicId,
-								 currentSlug,
-							 }: {
+	identity,
+	scheduledDraftsPromise,
+	snoozedThreadsPromise,
+	workspacePublicId,
+	currentSlug,
+}: {
 	identity: IdentityEntity;
 	scheduledDraftsPromise: Promise<DraftMessageEntity[]>;
 	snoozedThreadsPromise: Promise<{ threads: MailboxThreadEntity[] }>;
@@ -171,9 +171,7 @@ function IdentityExtraCounts({
 					} flex justify-start gap-1 w-full p-1.5 items-center`}
 				>
 					<Clock4 size={16} />
-					<span className="font-normal text-sm">
-						Snoozed ({snoozedCount})
-					</span>
+					<span className="font-normal text-sm">Snoozed ({snoozedCount})</span>
 				</Link>
 			)}
 		</>
@@ -181,13 +179,13 @@ function IdentityExtraCounts({
 }
 
 export default function IdentityMailboxesList({
-												  identityMailboxes,
-												  unreadCounts,
-												  scheduledDraftsPromise,
-												  snoozedThreadsPromise,
-												  workspacePublicId,
-												  onComplete,
-											  }: {
+	identityMailboxes,
+	unreadCounts,
+	scheduledDraftsPromise,
+	snoozedThreadsPromise,
+	workspacePublicId,
+	onComplete,
+}: {
 	identityMailboxes: FetchIdentityMailboxListResult;
 	unreadCounts: FetchMailboxUnreadCountsResult;
 	scheduledDraftsPromise: Promise<DraftMessageEntity[]>;
@@ -211,14 +209,14 @@ export default function IdentityMailboxesList({
 		return parts.at(-1) ?? "inbox";
 	}, [pathname]);
 
-	const router = useRouter()
+	const router = useRouter();
 
 	const Item = ({
-					  m,
-					  identityPublicId,
-					  identity,
-					  level = 0,
-				  }: {
+		m,
+		identityPublicId,
+		identity,
+		level = 0,
+	}: {
 		m: TreeMailbox;
 		identityPublicId: string;
 		identity: IdentityEntity;
@@ -258,19 +256,7 @@ export default function IdentityMailboxesList({
 					<div className="flex w-full items-start">
 						<Link
 							href={href}
-							onClick={(e) => {
-								// Next.js doesn't reliably reset the intercepted @thread
-								// parallel-route slot when navigating back to the bare
-								// mailbox path from within an open thread (the mailboxSlug
-								// segment itself doesn't change), so the thread stays
-								// rendered on top of the list. Force a real navigation.
-								if (pathname.includes("/threads/")) {
-									e.preventDefault();
-									router.push(href);
-									router.refresh();
-								}
-								onComplete?.();
-							}}
+							onClick={onComplete ? () => onComplete() : undefined}
 							aria-disabled={!m.selectable}
 							className={cn(
 								"flex min-w-0 flex-1 items-center gap-2 rounded-md py-1.5 pl-2 text-sm",
@@ -280,7 +266,7 @@ export default function IdentityMailboxesList({
 									? "text-brand dark:text-white bg-brand-100 dark:bg-neutral-800 hover:text-brand hover:bg-brand-100"
 									: "",
 								!m.selectable &&
-								"opacity-60 pointer-events-none cursor-default",
+									"opacity-60 pointer-events-none cursor-default",
 							)}
 							style={{ paddingLeft: 8 + level * 8 }}
 						>
@@ -339,15 +325,19 @@ export default function IdentityMailboxesList({
 	return (
 		<div className="space-y-2 px-2">
 			<div className={"my-2"}>
-				<Select placeholder="Pick value"
-				        size={"xs"}
-				        onChange={(publicId) => {
-							router.push(`/w/${workspacePublicId}/dashboard/mail/${publicId}/inbox`)
-						}}
-				        value={params.identityPublicId}
-				        data={identityMailboxes.map((id) => {
-							return {value: id.identity.publicId, label: id.identity.value}
-						})} />
+				<Select
+					placeholder="Pick value"
+					size={"xs"}
+					onChange={(publicId) => {
+						router.push(
+							`/w/${workspacePublicId}/dashboard/mail/${publicId}/inbox`,
+						);
+					}}
+					value={params.identityPublicId}
+					data={identityMailboxes.map((id) => {
+						return { value: id.identity.publicId, label: id.identity.value };
+					})}
+				/>
 			</div>
 
 			{identityMailboxes.map(({ identity, mailboxes }) => {

--- a/apps/web/components/dashboard/identity-mailboxes-list.tsx
+++ b/apps/web/components/dashboard/identity-mailboxes-list.tsx
@@ -258,7 +258,19 @@ export default function IdentityMailboxesList({
 					<div className="flex w-full items-start">
 						<Link
 							href={href}
-							onClick={onComplete ? () => onComplete() : undefined}
+							onClick={(e) => {
+								// Next.js doesn't reliably reset the intercepted @thread
+								// parallel-route slot when navigating back to the bare
+								// mailbox path from within an open thread (the mailboxSlug
+								// segment itself doesn't change), so the thread stays
+								// rendered on top of the list. Force a real navigation.
+								if (pathname.includes("/threads/")) {
+									e.preventDefault();
+									router.push(href);
+									router.refresh();
+								}
+								onComplete?.();
+							}}
 							aria-disabled={!m.selectable}
 							className={cn(
 								"flex min-w-0 flex-1 items-center gap-2 rounded-md py-1.5 pl-2 text-sm",

--- a/apps/web/components/mailbox/default/thread-slot-reset.tsx
+++ b/apps/web/components/mailbox/default/thread-slot-reset.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { Fragment } from "react";
+
+/**
+ * The @thread parallel route is an intercepted slot rendered as a sibling
+ * of `children` in [mailboxSlug]/layout.tsx. Next.js only swaps that slot's
+ * content when the URL segments it actually matches change — clicking away
+ * from an open thread to the same mailboxSlug (e.g. "Inbox" while already
+ * viewing a thread under Inbox) doesn't change [mailboxSlug], so the slot's
+ * last-rendered thread view can stay mounted instead of falling back to
+ * @thread/default.tsx, even though the URL has already updated.
+ *
+ * Keying the slot by the current pathname forces React to unmount the
+ * stale thread subtree whenever the URL changes at all, so it always
+ * re-resolves against the new path instead of holding onto old content.
+ * Uses Fragment (not a div) so this doesn't add a DOM node into the
+ * surrounding flex/grid layout.
+ */
+export default function ThreadSlotReset({
+	children,
+}: {
+	children: React.ReactNode;
+}) {
+	const pathname = usePathname();
+	return <Fragment key={pathname}>{children}</Fragment>;
+}


### PR DESCRIPTION
Fixes #519

## Summary

When viewing a thread and clicking the same (or any) folder in the sidebar to go back to the message list, nothing happened — the thread stayed open. Related to the long-standing #425/#426/#427 cluster.

## Root cause

The mail routes use Next.js parallel + intercepting routes to render an open thread (`@thread` slot) over the message list (`children`), both mounted together in `apps/web/app/[locale]/w/[wPublicId]/dashboard/(unified)/(mail)/mail/[identityPublicId]/[mailboxSlug]/layout.tsx`.

The sidebar folder link (`apps/web/components/dashboard/identity-mailboxes-list.tsx`) is a plain `next/link` `<Link>` pointing at the bare mailbox path. When navigating away from an intercepted thread route back to that bare path, the `mailboxSlug` route segment itself doesn't change — only the intercepted child segment is dropped — so Next's router doesn't reliably reset the `@thread` slot back to its `default.tsx` (which renders `null`). The thread stays rendered on top of the list.

## Fix

In the sidebar `Item`'s `Link` `onClick`, when a thread is currently open (`pathname.includes("/threads/")`), prevent the default Link navigation and instead force `router.push(href)` followed by `router.refresh()`, which reliably resets the parallel-route tree. Normal folder-to-folder navigation (no thread open) is untouched — same default `Link` behavior as before.

## Scope note

There are two other near-duplicate sidebar nav components in the repo (`apps/web/components/dashboard/unified-mailbox-nav.tsx` and `apps/web/components/mailbox/default/mailbox-nav.tsx`) with the same underlying pattern, but neither is imported/rendered anywhere in the app (confirmed via repo-wide search) — only `identity-mailboxes-list.tsx`, wired through `IdentityMailboxesListWrapper` → `AppSidebar` (`ui/dashboards/unified/default/app-sidebar.tsx`), is on the live navigation path. Left those alone to keep this PR scoped to the actual bug.

## Notes

Ran `pnpm biome check` on the changed file — no findings on the touched lines (pre-existing `noExplicitAny`/`useImportType` warnings elsewhere in the file predate this change).