### PR TITLE
fix: DAV_URL example default points to internal Docker service name

### DIFF
--- a/.changeset/fix-dav-url-default.md
+++ b/.changeset/fix-dav-url-default.md
@@ -1,0 +1,5 @@
+---
+"@kurrier/repo": patch
+---
+
+Fix DAV_URL in db/example.env defaulting to the internal Docker service name (http://dav:80), which is never reachable by an external CalDAV/CardDAV client. Defaults to http://localhost:5232 now, matching the exposed host port and the dev env template. Documented that hosted deployments need to set DAV_URL to their own public domain, same as WEB_URL.

--- a/apps/docs/content/docs/installation.mdx
+++ b/apps/docs/content/docs/installation.mdx
@@ -95,6 +95,14 @@ you should use your own domain and disable tunneling by removing or commenting o
 WEB_URL=https://www.yourdomain.com
 ```
 
+<Callout type="warning">
+    `DAV_URL` also needs to be a publicly reachable address — it's the CalDAV/CardDAV
+    connection URL shown on the Sync Services page for configuring external clients
+    (Thunderbird, iOS, Android, etc). The default (`http://localhost:5232`) only works
+    for local setups. For a hosted deployment, set it to your own domain/port or a
+    reverse-proxied path, e.g. `DAV_URL=https://dav.yourdomain.com`.
+</Callout>
+
 ---
 
 ✅ Once you are all set with your environment variables you are now ready to run

--- a/db/example.env
+++ b/db/example.env
@@ -29,7 +29,7 @@ JWT_SECRET=TpLjgE4eqXMeZLEclNH5bLuME53eQ6Rsl67M98Je
 APP_SECRET_ENCRYPTION_KEY=s2Ef+V5lnMMcbh7NlLuIdxqbIp+cx2Q8Kec2eBGwrZk=
 SEARCH_REBUILD_ON_BOOT=false
 
-DAV_URL=http://dav:80
+DAV_URL=http://localhost:5232
 
 DAV_DATABASE_URL=postgresql://baikal:strong_baikal_password@baikal-postgres:5432/baikal
 WORKER_URL=http://worker:3001


### PR DESCRIPTION
Fixes #518

## Summary

`db/example.env` — the file the installation docs tell you to copy to `.env` for a real deploy — defaulted `DAV_URL` to `http://dav:80`, the internal Docker Compose service name for the Baikal container. That hostname only resolves container-to-container inside the compose network; it's never reachable by the actual consumer of this value — the CalDAV/CardDAV client (Thunderbird, iOS, Android, etc.) shown on the Sync Services page.

Every other backend-only variable in that file correctly uses the internal service name (`REDIS_HOST=redis`, `POSTGRES_HOST=postgres`, `WORKER_URL=http://worker:3001`, etc.) — those are consumed server-to-server and that's fine. `DAV_URL` is the odd one out: like `WEB_URL`, it's public-facing and meant to be reachable from the end user's own device, but it got the internal-service-name treatment by mistake.

`db/example.develop.env` already had the correct value on the same line (`http://localhost:5232`), confirming this was a mistake rather than intentional.

## Changes

- `db/example.env`: `DAV_URL=http://dav:80` → `DAV_URL=http://localhost:5232` (matches the host-exposed port from `ports: "5232:80"` in `docker-compose.yml`, and mirrors the dev template)
- `apps/docs/content/docs/installation.mdx`: added a callout in the Hosted Setup section noting that `DAV_URL`, like `WEB_URL`, needs to be the deployer's own public domain/port for a real hosted deployment — it wasn't documented anywhere before

## Testing note (non-blocking, separate from this fix)

While validating this on a real deployment behind a reverse proxy: the `.well-known` CalDAV/CardDAV discovery redirect from Baikal briefly resolves through `http://` before landing on `https://` — Baikal's internal nginx rewrite doesn't read `X-Forwarded-Proto`, so it issues the redirect assuming plain HTTP. It still works end-to-end (client follows the extra hop transparently), so it's not something this PR needs to address, but worth having on record — a future fix would mean customizing Baikal's bundled nginx config to honor the forwarded proto header.