### PR TITLE
fix: preserve https scheme in Baikal .well-known redirects behind a proxy

### DIFF
--- a/.changeset/fix-baikal-proxy-scheme.md
+++ b/.changeset/fix-baikal-proxy-scheme.md
@@ -1,0 +1,5 @@
+---
+"@kurrier/repo": patch
+---
+
+Fix Baikal's .well-known CalDAV/CardDAV redirect always resolving through http:// when Kurrier is deployed behind a reverse proxy terminating TLS. Mounts a corrected nginx config over the bundled one, deriving the redirect scheme from X-Forwarded-Proto instead of the container's own (always plain HTTP) connection scheme.

--- a/db/docker-compose.dev.yml
+++ b/db/docker-compose.dev.yml
@@ -22,6 +22,7 @@ services:
     volumes:
       - ./dav_config:/var/www/baikal/config
       - ./dav_data:/var/www/baikal/Specific
+      - ./dav_nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
 
   typesense:
     image: typesense/typesense:29.0

--- a/db/docker-compose.yml
+++ b/db/docker-compose.yml
@@ -44,6 +44,7 @@ services:
     volumes:
       - ./dav_config:/var/www/baikal/config
       - ./dav_data:/var/www/baikal/Specific
+      - ./dav_nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
 
   typesense:
     image: typesense/typesense:29.0

--- a/db/init/dav_nginx/default.conf
+++ b/db/init/dav_nginx/default.conf
@@ -1,0 +1,51 @@
+# Based on https://github.com/ckulka/baikal-docker/blob/master/files/nginx.conf
+#
+# Overrides the bundled config so the CalDAV/CardDAV .well-known redirects
+# preserve https:// when Kurrier is deployed behind a reverse proxy that
+# terminates TLS. The upstream rewrite-based redirect always uses nginx's
+# own connection scheme (plain http, since this container only ever listens
+# on port 80 internally) and ignores X-Forwarded-Proto. See:
+# https://github.com/sabre-io/Baikal/issues/1391
+
+server {
+  listen 80;
+  listen [::]:80;
+  server_name _;
+
+  root   /var/www/baikal/html;
+  index index.php;
+
+  set $proxy_scheme $scheme;
+  if ($http_x_forwarded_proto = "https") {
+    set $proxy_scheme https;
+  }
+
+  location = /.well-known/caldav {
+    return 301 $proxy_scheme://$host/dav.php;
+  }
+  location = /.well-known/carddav {
+    return 301 $proxy_scheme://$host/dav.php;
+  }
+
+  charset utf-8;
+
+  location ~ /(\.ht|Core|Specific) {
+    deny all;
+    return 404;
+  }
+
+  # Pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+  location ~ ^(.+\.php)(.*)$ {
+    try_files $fastcgi_script_name =404;
+    include        /etc/nginx/fastcgi_params;
+    fastcgi_split_path_info  ^(.+\.php)(.*)$;
+    fastcgi_pass   unix:/var/run/php-fpm.sock;
+    fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
+    fastcgi_param  PATH_INFO        $fastcgi_path_info;
+  }
+
+  # Deny access to Apache httpd .htaccess files, see https://github.com/JsBergbau/BaikalAnleitung#webserver-konfiguration
+  location ~ /.ht {
+    deny all;
+  }
+}


### PR DESCRIPTION
Fixes #522

## Summary

The `dav` service (`ckulka/baikal:nginx`) redirects `/.well-known/caldav` and `/.well-known/carddav` to `/dav.php` using a bare nginx `rewrite ... redirect`. That constructs the `Location` header from nginx's own connection scheme, which is always plain HTTP inside this container (it only ever listens on port 80 internally — see `ports: "5232:80"`). Behind any reverse proxy terminating TLS (the standard hosted setup), the redirect always comes back as `http://` regardless of how the client actually connected — an unnecessary extra hop, and per [sabre-io/Baikal#1391](https://github.com/sabre-io/Baikal/issues/1391) a source of outright discovery failures on some strict clients (iOS).

## Fix

No image fork/rebuild required. Kurrier already bind-mounts config into this container (`./dav_config:/var/www/baikal/config`) — same approach for nginx: mount a corrected `default.conf` over `/etc/nginx/conf.d/default.conf` (path confirmed from the image's own [Dockerfile](https://github.com/ckulka/baikal-docker/blob/master/nginx.dockerfile)). The new config (`db/init/dav_nginx/default.conf`) is the upstream file with only the two `.well-known` rules changed, deriving the scheme from `X-Forwarded-Proto` when present:

```nginx
set $proxy_scheme $scheme;
if ($http_x_forwarded_proto = "https") {
    set $proxy_scheme https;
}

location = /.well-known/caldav {
    return 301 $proxy_scheme://$host/dav.php;
}
location = /.well-known/carddav {
    return 301 $proxy_scheme://$host/dav.php;
}
```

Wired into both `db/docker-compose.yml` and `db/docker-compose.dev.yml` via a new volume line, following the exact pattern already used for `dav_config`/`dav_data`. Nothing else in the container changes — every other line in the config file is untouched from upstream.

## Testing

I wasn't able to spin up the containers to verify this live in this environment (Docker wasn't cooperating). The change is a minimal, targeted diff against the exact upstream config source, using a standard and well-documented nginx idiom for proxy-scheme detection (this specific `if` form — containing only a `set` — is one of the sanctioned safe uses per nginx's own guidance on avoiding `if`). Flagging this so a maintainer or reviewer can sanity-check the redirect behavior on a real deployment behind a proxy before merging.