### PR TITLE
feat: allow self-hosted instances to disable the Drive UI

### DIFF
--- a/apps/docs/content/docs/installation.mdx
+++ b/apps/docs/content/docs/installation.mdx
@@ -103,6 +103,21 @@ WEB_URL=https://www.yourdomain.com
     reverse-proxied path, e.g. `DAV_URL=https://dav.yourdomain.com`.
 </Callout>
 
+### Optional: hide Kurrier Drive
+
+If your organization uses a separate file platform, such as Nextcloud, you can
+hide Kurrier Drive and its storage-management UI:
+
+```bash
+DISABLE_DRIVE=true
+```
+
+Restart the web container after changing this value. This setting only disables
+Kurrier's Drive web interface. It does not disable the object storage used for
+email, raw EML files, or attachments, and it does not delete existing Drive
+data. Set the value back to `false` and restart the web container to restore the
+Drive interface.
+
 ---
 
 ✅ Once you are all set with your environment variables you are now ready to run

--- a/apps/web/app/[locale]/w/[wPublicId]/dashboard/(unified)/(drive)/layout.tsx
+++ b/apps/web/app/[locale]/w/[wPublicId]/dashboard/(unified)/(drive)/layout.tsx
@@ -10,12 +10,19 @@ import {Suspense} from "react";
 import Loading from "@/app/loading";
 import NavUserWrapper from "@/components/ui/dashboards/workspace/nav-user-wrapper";
 import {getWorkspacePublicId} from "@/lib/actions/clients";
+import { redirect } from "next/navigation";
+import { SITE_FEATURES } from "@/lib/site-features";
 
 export default async function DriveLayout({
                                               children,
                                           }: {
     children: React.ReactNode;
 }) {
+    const workspacePublicId = await getWorkspacePublicId();
+    if (!SITE_FEATURES.drive) {
+        redirect(`/w/${workspacePublicId}/dashboard/mail`);
+    }
+
     const vols = await fetchVolumes();
     const userId = await isSignedIn();
     const initialState: DriveState = {
@@ -24,8 +31,6 @@ export default async function DriveLayout({
         driveRouteContext: null,
         userId: String(userId?.id),
     };
-    const workspacePublicId = await getWorkspacePublicId();
-
     return (
         <>
             <DynamicContextProvider initialState={initialState}>

--- a/apps/web/app/[locale]/w/[wPublicId]/dashboard/(unified)/(platform)/platform/overview/page.tsx
+++ b/apps/web/app/[locale]/w/[wPublicId]/dashboard/(unified)/(platform)/platform/overview/page.tsx
@@ -22,12 +22,14 @@ import { Separator } from "@/components/ui/separator";
 import React from "react";
 import { getWorkspacePublicId, getWorkspaceRole } from "@/lib/actions/clients";
 import { fetchWorkspace } from "@/lib/actions/workspace";
+import { SITE_FEATURES } from "@/lib/site-features";
 
 export default async function Page() {
 	const { data: statsData } = await getDashboardStats();
 	const workspacePublicId = await getWorkspacePublicId();
 	const workspaceRole = await getWorkspaceRole();
 	const workspace = await fetchWorkspace();
+	const driveEnabled = SITE_FEATURES.drive;
 
 	const isOwner = workspaceRole === "owner";
 	const base = `/w/${workspacePublicId}/dashboard/platform`;
@@ -38,7 +40,9 @@ export default async function Page() {
 				icon: <Plug className="size-5 text-primary" />,
 				label: "Connected Providers",
 				value: statsData?.connectedProviders || 0,
-				hint: "Sending and storage integrations",
+				hint: driveEnabled
+					? "Sending and storage integrations"
+					: "Connected integrations",
 			},
 			{
 				icon: <Send className="size-5 text-primary" />,
@@ -109,13 +113,15 @@ export default async function Page() {
 			done: Number(statsData?.activeIdentities || 0) > 0,
 			href: `${base}/identities`,
 		},
-		{
+	];
+	if (driveEnabled) {
+		setupItems.push({
 			title: "Create a storage volume",
 			description: "Add a Drive volume for workspace files.",
 			done: Number(statsData?.volumeCount || 0) > 0,
 			href: `${base}/storage`,
-		},
-	];
+		});
+	}
 
 	const quickActions = [
 		{
@@ -128,11 +134,15 @@ export default async function Page() {
 			title: "Identities",
 			href: `${base}/identities`,
 		},
-		{
+	];
+	if (driveEnabled) {
+		quickActions.push({
 			icon: <HardDrive className="size-4" />,
 			title: "Storage",
 			href: `${base}/storage`,
-		},
+		});
+	}
+	quickActions.push(
 		{
 			icon: <Webhook className="size-4" />,
 			title: "Webhooks",
@@ -143,7 +153,45 @@ export default async function Page() {
 			title: "Sync services",
 			href: `${base}/sync-services`,
 		},
+	);
+	const ownerStorageRows: [string, string][] = [
+		["Raw EML", formatBytes(statsData?.rawMessageBytes || 0)],
+		["Attachments", formatBytes(statsData?.attachmentBytes || 0)],
 	];
+	if (driveEnabled) {
+		ownerStorageRows.push([
+			"Drive files",
+			formatBytes(statsData?.driveStorageBytes || 0),
+		]);
+	}
+	ownerStorageRows.push([
+		"Total",
+		formatBytes(
+			statsData?.totalStorageBytes || statsData?.storageBytesUsed || 0,
+		),
+	]);
+	const ownerConfigurationRows: [string, string][] = [
+		["Providers", formatNumber(statsData?.connectedProviders || 0)],
+		["Verified domains", formatNumber(statsData?.verifiedDomains || 0)],
+		["Identities", formatNumber(statsData?.activeIdentities || 0)],
+	];
+	if (driveEnabled) {
+		ownerConfigurationRows.push([
+			"Volumes",
+			formatNumber(statsData?.volumeCount || 0),
+		]);
+	}
+	const ownerRecordRows: [string, string][] = [
+		["Messages", formatNumber(statsData?.emailsProcessedTotal || 0)],
+		["Threads", formatNumber(statsData?.threadCount || 0)],
+		["Drafts", formatNumber(statsData?.draftCount || 0)],
+	];
+	if (driveEnabled) {
+		ownerRecordRows.push([
+			"Drive entries",
+			formatNumber(statsData?.driveEntryCount || 0),
+		]);
+	}
 
 	return (
 		<>
@@ -177,7 +225,9 @@ export default async function Page() {
 
 									<p className="mt-2 text-sm leading-6 text-muted-foreground">
 										{isOwner
-											? "Track setup, mail volume, stored messages, Drive files and workspace storage from one place."
+											? driveEnabled
+												? "Track setup, mail volume, stored messages, Drive files and workspace storage from one place."
+												: "Track setup, mail volume and stored messages from one place."
 											: "Track your accessible mail, threads, drafts and stored messages from one place."}
 									</p>
 								</div>
@@ -295,28 +345,7 @@ export default async function Page() {
 								title="Storage"
 								rows={
 									isOwner
-										? [
-											[
-												"Raw EML",
-												formatBytes(statsData?.rawMessageBytes || 0),
-											],
-											[
-												"Attachments",
-												formatBytes(statsData?.attachmentBytes || 0),
-											],
-											[
-												"Drive files",
-												formatBytes(statsData?.driveStorageBytes || 0),
-											],
-											[
-												"Total",
-												formatBytes(
-													statsData?.totalStorageBytes ||
-													statsData?.storageBytesUsed ||
-													0,
-												),
-											],
-										]
+										? ownerStorageRows
 										: [
 											[
 												"Raw EML",
@@ -342,21 +371,7 @@ export default async function Page() {
 								<MiniPanel
 									icon={<Globe className="size-4" />}
 									title="Configuration"
-									rows={[
-										[
-											"Providers",
-											formatNumber(statsData?.connectedProviders || 0),
-										],
-										[
-											"Verified domains",
-											formatNumber(statsData?.verifiedDomains || 0),
-										],
-										[
-											"Identities",
-											formatNumber(statsData?.activeIdentities || 0),
-										],
-										["Volumes", formatNumber(statsData?.volumeCount || 0)],
-									]}
+									rows={ownerConfigurationRows}
 								/>
 							) : null}
 
@@ -365,24 +380,7 @@ export default async function Page() {
 								title="Records"
 								rows={
 									isOwner
-										? [
-											[
-												"Messages",
-												formatNumber(statsData?.emailsProcessedTotal || 0),
-											],
-											[
-												"Threads",
-												formatNumber(statsData?.threadCount || 0),
-											],
-											[
-												"Drafts",
-												formatNumber(statsData?.draftCount || 0),
-											],
-											[
-												"Drive entries",
-												formatNumber(statsData?.driveEntryCount || 0),
-											],
-										]
+										? ownerRecordRows
 										: [
 											[
 												"Messages",

--- a/apps/web/app/[locale]/w/[wPublicId]/dashboard/(unified)/(platform)/platform/storage/page.tsx
+++ b/apps/web/app/[locale]/w/[wPublicId]/dashboard/(unified)/(platform)/platform/storage/page.tsx
@@ -13,11 +13,17 @@ import {getWorkspacePublicId, rlsClient} from "@/lib/actions/clients";
 import { driveVolumes, providerSecrets, smtpAccountSecrets } from "@db";
 import { parseSecret } from "@/lib/utils";
 import ProviderCardShell from "@/components/dashboard/providers/provider-card-shell";
+import { redirect } from "next/navigation";
+import { SITE_FEATURES } from "@/lib/site-features";
 
 export default async function ProvidersPage() {
+	const workspacePublicId = await getWorkspacePublicId()
+	if (!SITE_FEATURES.drive) {
+		redirect(`/w/${workspacePublicId}/dashboard/platform/overview`);
+	}
+
 	const userProviders = await syncProviders();
 	const rls = await rlsClient();
-	const workspacePublicId = await getWorkspacePublicId()
 	const vols = await rls((tx) => tx.select().from(driveVolumes));
 	const [, userProviderAccounts] = await Promise.all([
 		fetchDecryptedSecrets({

--- a/apps/web/app/api/drive/upload/route.ts
+++ b/apps/web/app/api/drive/upload/route.ts
@@ -4,10 +4,15 @@ import { and, eq, gt, isNull } from "drizzle-orm";
 import { driveUploadIntents, driveVolumes } from "@db";
 import { s3 } from "@/lib/create-s3-client";
 import { rlsClient } from "@/lib/actions/clients";
+import { SITE_FEATURES } from "@/lib/site-features";
 
 const trimSlashes = (s: string) => s.replace(/^\/+|\/+$/g, "");
 
 export async function POST(req: NextRequest) {
+    if (!SITE_FEATURES.drive) {
+        return NextResponse.json({ error: "Drive is disabled" }, { status: 404 });
+    }
+
     const formData = await req.formData();
 
     const file = formData.get("file") as File | null;

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,19 +1,20 @@
 import type { Metadata } from "next";
-import { cookies } from "next/headers";
 import { JetBrains_Mono, Plus_Jakarta_Sans } from "next/font/google";
+import { cookies } from "next/headers";
 import "./globals.css";
-import { ConfigProvider } from "@/components/providers/config-provider";
-import { AppearanceProvider } from "@/components/providers/appearance-provider";
+import { getPublicEnv } from "@schema";
 import {
 	MODE_COOKIE,
 	RESOLVED_COOKIE,
 	THEME_COOKIE,
-	ThemeMode,
+	type ThemeMode,
 	ThemeModeSchema,
-	ThemeName,
+	type ThemeName,
 	ThemeNameSchema,
 } from "@schema/types/themes";
-import { getPublicEnv } from "@schema";
+import { AppearanceProvider } from "@/components/providers/appearance-provider";
+import { ConfigProvider } from "@/components/providers/config-provider";
+import { SiteFeaturesProvider } from "@/components/providers/site-features-provider";
 import "@mantine/core/styles.css";
 import "@mantine/dates/styles.css";
 import {
@@ -21,8 +22,9 @@ import {
 	MantineProvider,
 	mantineHtmlProps,
 } from "@mantine/core";
-import { createMantineTheme } from "@/lib/mantine-theme";
 import { ModalsProvider } from "@mantine/modals";
+import { createMantineTheme } from "@/lib/mantine-theme";
+import { SITE_FEATURES } from "@/lib/site-features";
 
 const jakartaSans = Plus_Jakarta_Sans({
 	variable: "--font-sans",
@@ -81,12 +83,14 @@ export default async function RootLayout({
 			>
 				<AppearanceProvider initialTheme={theme} initialMode={mode}>
 					<ConfigProvider value={publicConfig}>
-						<MantineProvider
-							theme={mantineTheme}
-							defaultColorScheme={colorScheme}
-						>
-							<ModalsProvider>{children}</ModalsProvider>
-						</MantineProvider>
+						<SiteFeaturesProvider value={SITE_FEATURES}>
+							<MantineProvider
+								theme={mantineTheme}
+								defaultColorScheme={colorScheme}
+							>
+								<ModalsProvider>{children}</ModalsProvider>
+							</MantineProvider>
+						</SiteFeaturesProvider>
 					</ConfigProvider>
 				</AppearanceProvider>
 			</body>

--- a/apps/web/components/nav-main.tsx
+++ b/apps/web/components/nav-main.tsx
@@ -30,9 +30,11 @@ import {
 } from "@/components/ui/sidebar";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useSiteFeatures } from "@/components/providers/site-features-provider";
 
 export function NavMain({workspacePublicId, workspaceRole}: {workspacePublicId?: string, workspaceRole?: string}) {
 	const pathname = usePathname();
+	const { drive } = useSiteFeatures();
 
 	const navPlatformItems: {
 		title: string;
@@ -70,12 +72,16 @@ export function NavMain({workspacePublicId, workspaceRole}: {workspacePublicId?:
 					icon: Blocks,
 					items: [],
 				},
-				{
-					title: "Storage",
-					url: `/w/${workspacePublicId}/dashboard/platform/storage`,
-					icon: HardDrive,
-					items: [],
-				},
+				...(drive
+					? [
+							{
+								title: "Storage",
+								url: `/w/${workspacePublicId}/dashboard/platform/storage`,
+								icon: HardDrive,
+								items: [],
+							},
+						]
+					: []),
 				{
 					title: "Vault",
 					url: `/w/${workspacePublicId}/dashboard/platform/vault`,

--- a/apps/web/components/providers/site-features-provider.tsx
+++ b/apps/web/components/providers/site-features-provider.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { createContext, useContext } from "react";
+import type { SiteFeatures } from "@/lib/site-features";
+
+const SiteFeaturesContext = createContext<SiteFeatures | undefined>(undefined);
+
+export function SiteFeaturesProvider({
+	value,
+	children,
+}: {
+	value: SiteFeatures;
+	children: React.ReactNode;
+}) {
+	return (
+		<SiteFeaturesContext.Provider value={value}>
+			{children}
+		</SiteFeaturesContext.Provider>
+	);
+}
+
+export function useSiteFeatures() {
+	const features = useContext(SiteFeaturesContext);
+	if (!features) {
+		throw new Error(
+			"useSiteFeatures must be used within <SiteFeaturesProvider>",
+		);
+	}
+	return features;
+}

--- a/apps/web/components/ui/dashboards/unified/default/app-sidebar.tsx
+++ b/apps/web/components/ui/dashboards/unified/default/app-sidebar.tsx
@@ -23,6 +23,7 @@ import Link from "next/link";
 import { useMediaQuery } from "@mantine/hooks";
 import { Divider } from "@mantine/core";
 import { IconFrame } from "@tabler/icons-react";
+import { useSiteFeatures } from "@/components/providers/site-features-provider";
 
 type UnifiedSidebarProps = React.ComponentProps<typeof Sidebar> & {
 	navUserContent: React.ReactNode;
@@ -32,6 +33,7 @@ type UnifiedSidebarProps = React.ComponentProps<typeof Sidebar> & {
 };
 
 export function AppSidebar({ ...props }: UnifiedSidebarProps) {
+	const { drive } = useSiteFeatures();
 	const {
 		sidebarSectionContent,
 		sidebarTopContent,
@@ -62,12 +64,16 @@ export function AppSidebar({ ...props }: UnifiedSidebarProps) {
 				icon: Calendar,
 				isActive: true,
 			},
-			{
-				title: "Drive",
-				url: `/w/${workspacePublicId}/dashboard/drive`,
-				icon: HardDrive,
-				isActive: true,
-			},
+			...(drive
+				? [
+						{
+							title: "Drive",
+							url: `/w/${workspacePublicId}/dashboard/drive`,
+							icon: HardDrive,
+							isActive: true,
+						},
+					]
+				: []),
 			{
 				title: "Platform",
 				url: `/w/${workspacePublicId}/dashboard/platform/overview`,

--- a/apps/web/lib/actions/dashboard.ts
+++ b/apps/web/lib/actions/dashboard.ts
@@ -57,6 +57,7 @@ import {
 import {workspaceIdentityMembers} from "@db";
 import {s3} from "@/lib/create-s3-client";
 import {CreateBucketCommand} from "@aws-sdk/client-s3";
+import { SITE_FEATURES } from "@/lib/site-features";
 
 const DASHBOARD_PATH = "/w/[workspaceId]/dashboard/providers";
 const CURRENT_API_VERSION = 1;
@@ -82,6 +83,17 @@ export async function upsertProviderAccount(
 		const parsed = ProviderAccountFormSchema.parse(data);
 
 		const rls = await rlsClient();
+		if (!SITE_FEATURES.drive) {
+			const [provider] = await rls((tx) =>
+				tx
+					.select({ type: providers.type })
+					.from(providers)
+					.where(eq(providers.id, String(parsed.providerId))),
+			);
+			if (provider?.type === "s3") {
+				throw new Error("Drive is disabled");
+			}
+		}
 		const [providerSecret] = await rls((tx) =>
 			tx
 				.select()
@@ -1371,6 +1383,10 @@ export const regenerateDavPassword = async () => {
 
 export async function addNewVolume(_prev: FormState, formData: FormData) {
 	return handleAction(async () => {
+		if (!SITE_FEATURES.drive) {
+			throw new Error("Drive is disabled");
+		}
+
 		const rls = await rlsClient();
 		const data = decode(formData);
 		const user = await isSignedIn();

--- a/apps/web/lib/actions/drive.ts
+++ b/apps/web/lib/actions/drive.ts
@@ -20,11 +20,19 @@ import {
 } from "@aws-sdk/client-s3";
 import {s3} from "@/lib/create-s3-client";
 import {getSignedUrl} from "@aws-sdk/s3-request-presigner";
+import { SITE_FEATURES } from "@/lib/site-features";
 
 
 const trimSlashes = (s: string) => s.replace(/^\/+|\/+$/g, "");
 
+function assertDriveEnabled() {
+	if (!SITE_FEATURES.drive) {
+		throw new Error("Drive is disabled");
+	}
+}
+
 export const normalizeWithinPath = async (segments: string[]) => {
+	assertDriveEnabled();
 	const cleaned = (segments ?? [])
 		.filter(Boolean)
 		.map((s) => trimSlashes(decodeURIComponent(s)));
@@ -56,6 +64,7 @@ export const normalizeWithinPath = async (segments: string[]) => {
 };
 
 export const fetchVolumes = async () => {
+	assertDriveEnabled();
 	const user = await isSignedIn();
 	const rls = await rlsClient();
 	return rls((tx) =>
@@ -67,6 +76,7 @@ export const fetchVolumes = async () => {
 };
 
 export const normalizeWithinPathString = async (path: unknown) => {
+	assertDriveEnabled();
 	const raw = typeof path === "string" ? path : "/";
 	const cleaned = "/" + trimSlashes(decodeURIComponent(raw));
 	return cleaned === "/" ? "/" : cleaned;
@@ -95,6 +105,7 @@ export async function addNewFolder(
 	formData: FormData,
 ): Promise<FormState> {
 	return handleAction(async () => {
+		assertDriveEnabled();
 		const decodedForm = decode(formData) as Record<string, unknown>;
 
 		const name =
@@ -221,6 +232,7 @@ export async function addNewFolder(
 
 
 export const refreshViewAfterUpload = async () => {
+	assertDriveEnabled();
 	return revalidatePath("/w/[workspaceId]/dashboard/drive");
 };
 
@@ -229,6 +241,7 @@ function getVolumePrefix(volume: DriveVolumeEntity) {
 }
 
 export async function fetchCloudListPath(ctx: DriveRouteContext) {
+	assertDriveEnabled();
 	const volume = ctx.driveVolume;
 	if (!volume) return [];
 
@@ -350,6 +363,7 @@ export async function getCloudUploadUrl(
 		contentType?: string | null;
 	},
 ) {
+	assertDriveEnabled();
 	const volume = ctx.driveVolume;
 	if (!volume) throw new Error("Missing driveVolume");
 
@@ -414,6 +428,7 @@ export async function getCloudUploadUrl(
 
 
 export async function getDriveDownloadUrl(entryId: string) {
+	assertDriveEnabled();
 
 	const rls = await rlsClient();
 	const [entry] = await rls((tx) =>
@@ -438,6 +453,7 @@ export async function getDriveDownloadUrl(entryId: string) {
 
 export async function deleteDriveEntry(entryId: string) {
 	return handleAction(async () => {
+		assertDriveEnabled();
 		const rls = await rlsClient();
 
 		const [entry] = await rls((tx) =>

--- a/apps/web/lib/site-features.ts
+++ b/apps/web/lib/site-features.ts
@@ -1,0 +1,7 @@
+import "server-only";
+
+export const SITE_FEATURES = {
+	drive: process.env.DISABLE_DRIVE !== "true",
+} as const;
+
+export type SiteFeatures = typeof SITE_FEATURES;

--- a/db/example.develop.env
+++ b/db/example.develop.env
@@ -2,6 +2,10 @@ WEB_PORT=3000
 WEB_URL=http://localhost:3000
 NITRO_PORT=3001
 
+# Hide Kurrier Drive and storage management from the web UI.
+# Mail storage, attachments, and existing Drive data are not affected.
+DISABLE_DRIVE=false
+
 #LOCAL_TUNNEL_URL=https://your-ngrok-tunnel-url.ngrok-free.app
 
 REDIS_PASSWORD=replace_with_your_redis_password

--- a/db/example.env
+++ b/db/example.env
@@ -2,6 +2,10 @@ WEB_PORT=3000
 WEB_URL=http://localhost:3000
 NITRO_PORT=3001
 
+# Hide Kurrier Drive and storage management from the web UI.
+# Mail storage, attachments, and existing Drive data are not affected.
+DISABLE_DRIVE=false
+
 #LOCAL_TUNNEL_URL=https://your-ngrok-tunnel-url.ngrok-free.app
 
 REDIS_PASSWORD=replace_with_your_redis_password


### PR DESCRIPTION
Closes #529

## Summary

- add a public `DISABLE_DRIVE` environment flag that defaults to `false`
- hide Drive and Platform Storage navigation when the flag is enabled
- remove Drive-specific setup, actions, metrics, and wording from Platform Overview while preserving total storage usage
- redirect direct Drive and Storage page requests to Mail and Platform Overview
- return `404` from the Drive upload API and reject Drive/storage server actions from stale tabs
- document the flag and update both example environment files

## Data safety

- no Drive volumes, entries, or S3 objects are deleted
- mail storage, raw EML files, attachments, calendars, DAV services, and workers are unchanged
- setting the flag back to `false` restores the existing Drive data and UI

## Validation

- public config and Drive routing unit tests (8/8)
- web TypeScript check
- web production build with `DISABLE_DRIVE=true`
- docs production build
- targeted Biome and `git diff --check`
