### PR TITLE
fix: add default routes, not-found/error boundaries, fix locale-blind redirects

### DIFF
--- a/.changeset/add-default-routes.md
+++ b/.changeset/add-default-routes.md
@@ -1,0 +1,5 @@
+---
+"@kurrier/repo": patch
+---
+
+Add missing default routes ([locale], [locale]/w, dashboard index), a branded not-found/error page instead of Next's default, and fix several places where a redirect dropped the current locale (post-signup/login, auth layout guards). Also removes the dead, unreachable app/page.tsx that pointed at a stale route shape.

--- a/apps/web/app/[locale]/auth/layout.tsx
+++ b/apps/web/app/[locale]/auth/layout.tsx
@@ -1,15 +1,20 @@
-import { isSignedIn } from "@/lib/actions/auth";
 import { redirect } from "next/navigation";
+import { getDefaultWorkspacePath, isSignedIn } from "@/lib/actions/auth";
+import { withLocale } from "@/lib/utils";
 
 export default async function DashboardLayout({
 	children,
+	params,
 }: {
 	children: React.ReactNode;
+	params: Promise<{ locale: string }>;
 }) {
 	const user = await isSignedIn();
 
 	if (user) {
-		redirect("/dashboard/platform/overview");
+		const { locale } = await params;
+		const target = await getDefaultWorkspacePath(user as any);
+		redirect(withLocale(locale, target));
 	}
 
 	return <>{children}</>;

--- a/apps/web/app/[locale]/auth/signup/page.tsx
+++ b/apps/web/app/[locale]/auth/signup/page.tsx
@@ -1,22 +1,28 @@
+import { getPublicEnv } from "@schema";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import * as React from "react";
 import { SignupForm } from "@/components/auth/signup-form";
 import KurrierLogo from "@/components/common/kurrier-logo";
-import Link from "next/link";
-import * as React from "react";
-import { getPublicEnv } from "@schema";
-import { redirect } from "next/navigation";
-import {getDictionary, Locale} from "@/lib/dictionaries";
+import { getDictionary, type Locale } from "@/lib/dictionaries";
 import { getGenericOidcSettings } from "@/lib/generic-oidc";
+import { withLocale } from "@/lib/utils";
 
-export default async function SignupPage({ params }: { params: Promise<{ locale: Locale }>; }) {
+export default async function SignupPage({
+	params,
+}: {
+	params: Promise<{ locale: Locale }>;
+}) {
 	const { DISABLE_SIGNUP } = getPublicEnv();
-	const googleEnabled = process.env.OIDC_GOOGLE_CLIENT_ID && process.env.OIDC_GOOGLE_CLIENT_SECRET;
+	const googleEnabled =
+		process.env.OIDC_GOOGLE_CLIENT_ID && process.env.OIDC_GOOGLE_CLIENT_SECRET;
 	const genericOidc = getGenericOidcSettings();
+	const nParams = await params;
 
 	if (DISABLE_SIGNUP) {
-		redirect("/auth/login?message=signup_disabled");
+		redirect(withLocale(nParams.locale, "/auth/login?message=signup_disabled"));
 	}
 
-	const nParams = await params;
 	const dict = await getDictionary(nParams.locale);
 
 	return (
@@ -29,11 +35,14 @@ export default async function SignupPage({ params }: { params: Promise<{ locale:
 					<KurrierLogo size={56} />
 					<span className="truncate font-medium text-4xl">Kurrier</span>
 				</Link>
-				<SignupForm oidc={{
-					googleEnabled: !!googleEnabled,
-					genericEnabled: !!genericOidc,
-					genericName: genericOidc?.providerName,
-				}} dict={dict}  />
+				<SignupForm
+					oidc={{
+						googleEnabled: !!googleEnabled,
+						genericEnabled: !!genericOidc,
+						genericName: genericOidc?.providerName,
+					}}
+					dict={dict}
+				/>
 			</div>
 		</div>
 	);

--- a/apps/web/app/[locale]/not-found.tsx
+++ b/apps/web/app/[locale]/not-found.tsx
@@ -1,0 +1,5 @@
+import NotFoundView from "@/components/common/not-found-view";
+
+export default function LocaleNotFound() {
+	return <NotFoundView />;
+}

--- a/apps/web/app/[locale]/page.tsx
+++ b/apps/web/app/[locale]/page.tsx
@@ -1,0 +1,19 @@
+import { redirect } from "next/navigation";
+import { getDefaultWorkspacePath, isSignedIn } from "@/lib/actions/auth";
+import { withLocale } from "@/lib/utils";
+
+export default async function LocaleIndexPage({
+	params,
+}: {
+	params: Promise<{ locale: string }>;
+}) {
+	const { locale } = await params;
+	const user = await isSignedIn();
+
+	if (!user) {
+		redirect(withLocale(locale, "/auth/login"));
+	}
+
+	const target = await getDefaultWorkspacePath(user as any);
+	redirect(withLocale(locale, target));
+}

--- a/apps/web/app/[locale]/w/[wPublicId]/dashboard/page.tsx
+++ b/apps/web/app/[locale]/w/[wPublicId]/dashboard/page.tsx
@@ -1,0 +1,11 @@
+import { redirect } from "next/navigation";
+import { withLocale } from "@/lib/utils";
+
+export default async function DashboardIndexPage({
+	params,
+}: {
+	params: Promise<{ locale: string; wPublicId: string }>;
+}) {
+	const { locale, wPublicId } = await params;
+	redirect(withLocale(locale, `/w/${wPublicId}/dashboard/platform/overview`));
+}

--- a/apps/web/app/[locale]/w/layout.tsx
+++ b/apps/web/app/[locale]/w/layout.tsx
@@ -1,18 +1,20 @@
-import { isSignedIn } from "@/lib/actions/auth";
 import { redirect } from "next/navigation";
+import { isSignedIn } from "@/lib/actions/auth";
+import { withLocale } from "@/lib/utils";
 
 export default async function DashboardLayout({
 	children,
+	params,
 }: {
 	children: React.ReactNode;
+	params: Promise<{ locale: string }>;
 }) {
 	const user = await isSignedIn();
 
 	if (!user) {
-		redirect("/auth/login");
+		const { locale } = await params;
+		redirect(withLocale(locale, "/auth/login"));
 	}
 
-	return <>
-		{children}
-	</>
+	return <>{children}</>;
 }

--- a/apps/web/app/[locale]/w/page.tsx
+++ b/apps/web/app/[locale]/w/page.tsx
@@ -1,0 +1,19 @@
+import { redirect } from "next/navigation";
+import { getDefaultWorkspacePath, isSignedIn } from "@/lib/actions/auth";
+import { withLocale } from "@/lib/utils";
+
+export default async function WorkspaceIndexPage({
+	params,
+}: {
+	params: Promise<{ locale: string }>;
+}) {
+	const { locale } = await params;
+	const user = await isSignedIn();
+
+	if (!user) {
+		redirect(withLocale(locale, "/auth/login"));
+	}
+
+	const target = await getDefaultWorkspacePath(user as any);
+	redirect(withLocale(locale, target));
+}

--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useEffect } from "react";
+import KurrierLogo from "@/components/common/kurrier-logo";
+
+const LOCALES = ["en", "ko"];
+
+export default function GlobalError({
+	error,
+	reset,
+}: {
+	error: Error & { digest?: string };
+	reset: () => void;
+}) {
+	const pathname = usePathname();
+	const firstSegment = pathname.split("/")[1] ?? "";
+	const locale = LOCALES.includes(firstSegment) ? firstSegment : "en";
+
+	useEffect(() => {
+		console.error(error);
+	}, [error]);
+
+	return (
+		<div className="flex min-h-svh flex-col items-center justify-center gap-6 p-6 text-center">
+			<Link href={`/${locale}`} className="flex items-center gap-2 font-medium">
+				<KurrierLogo size={40} />
+				<span className="text-2xl font-medium">Kurrier</span>
+			</Link>
+			<div className="space-y-2">
+				<h1 className="text-2xl font-semibold">Something went wrong</h1>
+				<p className="text-sm text-muted-foreground">
+					An unexpected error occurred. You can try again, or head back home.
+				</p>
+			</div>
+			<div className="flex gap-4">
+				<button
+					type="button"
+					onClick={reset}
+					className="text-sm underline underline-offset-4"
+				>
+					Try again
+				</button>
+				<Link
+					href={`/${locale}`}
+					className="text-sm underline underline-offset-4"
+				>
+					Back to Kurrier
+				</Link>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,0 +1,5 @@
+import NotFoundView from "@/components/common/not-found-view";
+
+export default function RootNotFound() {
+	return <NotFoundView />;
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,5 +1,0 @@
-import { redirect } from "next/navigation";
-
-export default function Home() {
-	redirect("/dashboard/platform/overview");
-}

--- a/apps/web/components/common/not-found-view.tsx
+++ b/apps/web/components/common/not-found-view.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import KurrierLogo from "@/components/common/kurrier-logo";
+
+const LOCALES = ["en", "ko"];
+
+export default function NotFoundView() {
+	const pathname = usePathname();
+	const firstSegment = pathname.split("/")[1] ?? "";
+	const locale = LOCALES.includes(firstSegment) ? firstSegment : "en";
+
+	return (
+		<div className="flex min-h-svh flex-col items-center justify-center gap-6 p-6 text-center">
+			<Link href={`/${locale}`} className="flex items-center gap-2 font-medium">
+				<KurrierLogo size={40} />
+				<span className="text-2xl font-medium">Kurrier</span>
+			</Link>
+			<div className="space-y-2">
+				<h1 className="text-2xl font-semibold">Page not found</h1>
+				<p className="text-sm text-muted-foreground">
+					The page you're looking for doesn't exist or may have been moved.
+				</p>
+			</div>
+			<Link
+				href={`/${locale}`}
+				className="text-sm underline underline-offset-4"
+			>
+				Back to Kurrier
+			</Link>
+		</div>
+	);
+}

--- a/apps/web/lib/actions/auth.ts
+++ b/apps/web/lib/actions/auth.ts
@@ -1,20 +1,19 @@
 "use server";
 
+import * as crypto from "node:crypto";
 import { APP_VERSION } from "@common";
-import { db, identities, users, workspaces, workspaceMembers } from "@db";
-import { FormState, getPublicEnv, getServerEnv } from "@schema";
+import { db, identities, users, workspaceMembers, workspaces } from "@db";
+import { type FormState, getPublicEnv, getServerEnv } from "@schema";
 import argon2 from "argon2";
 import { Queue, QueueEvents } from "bullmq";
 import { decode } from "decode-formdata";
 import { eq } from "drizzle-orm";
-import { jwtVerify, JWTPayload, SignJWT } from "jose";
+import { type JWTPayload, jwtVerify, SignJWT } from "jose";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
-import * as crypto from "node:crypto";
 import { getRedis } from "@/lib/actions/get-redis";
 import { updateWorkSpaceContext } from "@/lib/actions/workspace";
-import {withLocale} from "@/lib/utils";
-
+import { withLocale } from "@/lib/utils";
 
 const initProviders = async (userId: string, workspaceId: string) => {
 	const { REDIS_PASSWORD, REDIS_HOST, REDIS_PORT } = getServerEnv();
@@ -132,9 +131,13 @@ export async function createUserWithWorkspace(opts: {
 	return user;
 }
 
-export async function signInUserAndRedirect(user: typeof users.$inferSelect,  locale?: string) {
+export async function signInUserAndRedirect(
+	user: typeof users.$inferSelect,
+	locale?: string,
+) {
 	await createSessionForUser(user.id);
-	redirect(await getWorkspaceRedirectUrl(user));
+	const target = await getWorkspaceRedirectUrl(user);
+	redirect(locale ? withLocale(locale, target) : target);
 }
 
 export async function login(
@@ -181,10 +184,11 @@ export async function signup(
 		};
 	}
 
-	const { workspaceName, email, password } = decode(formData) as {
+	const { workspaceName, email, password, locale } = decode(formData) as {
 		email: string;
 		password: string;
 		workspaceName: string;
+		locale?: string;
 	};
 
 	if (!email || !password) {
@@ -203,7 +207,7 @@ export async function signup(
 		return { error: user.error };
 	}
 
-	await signInUserAndRedirect(user);
+	await signInUserAndRedirect(user, locale);
 
 	return { success: true, message: "Welcome!" };
 }
@@ -280,13 +284,12 @@ export const getGravatarUrl = async (email: string, size = 80) => {
 	return `https://www.gravatar.com/avatar/${hash}?s=${size}&d=identicon`;
 };
 
-
 export async function createSessionForUser(userId: string) {
 	const token = await signToken(userId);
 	await setAuthToken(token);
 }
 
-export async function getWorkspaceRedirectUrl(user: typeof users.$inferSelect, locale?: string) {
+export async function getWorkspaceRedirectUrl(user: typeof users.$inferSelect) {
 	const [workspace] = await db
 		.select()
 		.from(workspaces)
@@ -305,9 +308,36 @@ export async function getWorkspaceRedirectUrl(user: typeof users.$inferSelect, l
 			.where(eq(identities.id, workspace.defaultIdentityId));
 
 		if (defaultIdentity) {
-			if (locale) {
-				redirect(withLocale(locale,`/w/${workspace.publicId}/dashboard/platform/overview`));
-			}
+			return `/w/${workspace.publicId}/dashboard/mail/${defaultIdentity.publicId}/inbox`;
+		}
+	}
+
+	return `/w/${workspace.publicId}/dashboard/platform/overview`;
+}
+
+/**
+ * Read-only counterpart to getWorkspaceRedirectUrl: same target resolution,
+ * but never writes the workspace-context cookies (that's only legal from a
+ * Server Action or Route Handler). Safe to call from a plain page/layout
+ * render to figure out where to redirect an already-signed-in user.
+ */
+export async function getDefaultWorkspacePath(user: typeof users.$inferSelect) {
+	const [workspace] = await db
+		.select()
+		.from(workspaces)
+		.where(eq(workspaces.ownerId, user.id));
+
+	if (!workspace) {
+		return "/auth/login";
+	}
+
+	if (workspace.defaultIdentityId) {
+		const [defaultIdentity] = await db
+			.select()
+			.from(identities)
+			.where(eq(identities.id, workspace.defaultIdentityId));
+
+		if (defaultIdentity) {
 			return `/w/${workspace.publicId}/dashboard/mail/${defaultIdentity.publicId}/inbox`;
 		}
 	}


### PR DESCRIPTION
Fixes #548.

## Summary

- Adds `[locale]/page.tsx`, `[locale]/w/page.tsx` and `w/[wPublicId]/dashboard/page.tsx` so every "container" level of the route tree resolves to something (redirect to the user's workspace, or to login) instead of a bare 404.
- Adds a root `not-found.tsx` and a nested `[locale]/not-found.tsx` (sharing a `NotFoundView` component), plus a root `error.tsx` boundary. Both not-found files are needed: Next only auto-selects a nested `not-found.tsx` when `notFound()` is thrown from within that segment — a genuinely unmatched path still falls through to the root one.
- Removes `app/page.tsx`: unreachable dead code (`proxy.ts` always redirects `/` to `/{locale}` first) that also pointed at a route shape (`/dashboard/platform/overview`) predating the `[locale]/w/[wPublicId]` segments.
- Fixes locale-blind redirects in `auth/layout.tsx`, `w/layout.tsx`, and `auth/signup/page.tsx`'s `signup_disabled` redirect.
- Fixes `signup()`/`signInUserAndRedirect()` silently dropping the locale on the post-signup/login redirect — `signInUserAndRedirect` accepted a `locale` param but never used it, and `signup()` never even extracted it from the form despite the form already sending it. Also found `getWorkspaceRedirectUrl` had inconsistent behavior depending on whether `locale` was passed (different target URL, and an internal `redirect()` call in only one branch) — simplified it to always return a plain path and let the caller apply the locale prefix.
- Adds `getDefaultWorkspacePath()`: a read-only counterpart to `getWorkspaceRedirectUrl` for use from plain page/layout renders, which can't write cookies the way `getWorkspaceRedirectUrl`'s `updateWorkSpaceContext()` call does (Next.js only allows cookie writes from Server Actions/Route Handlers). Calling `getWorkspaceRedirectUrl` directly from the new index pages crashed with "Cookies can only be modified in a Server Action or Route Handler."

## Test plan

- [x] `pnpm tsc --noEmit` clean (no new errors)
- [x] `pnpm biome check` on touched files, no new findings
- [x] Manually verified in a local dev environment: `/`, `/en`, `/en/w`, `/en/w/<id>/dashboard` all resolve correctly both signed-out (→ login) and signed-in (→ workspace)
- [x] Verified an unmatched path renders the new branded 404 instead of Next's default
- [x] Verified signup → redirect keeps the `/en/...` prefix (was dropping it before this fix)
- [x] Verified `/en/auth/login` and `/en/auth/signup` while already signed in redirect correctly without crashing