### PR TITLE
fix: redis/typesense restart policy, dev compose init path + image pin

### DIFF
--- a/db/docker-compose.dev.yml
+++ b/db/docker-compose.dev.yml
@@ -3,6 +3,7 @@ version: "3.9"
 services:
   redis:
     image: redis:8.2.2
+    restart: unless-stopped
     command: [ "redis-server", "--appendonly", "yes", "--stop-writes-on-bgsave-error","no", "--requirepass", "${REDIS_PASSWORD}" ]
     healthcheck:
       test: [ "CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "PING" ]
@@ -25,7 +26,7 @@ services:
 
   typesense:
     image: typesense/typesense:29.0
-    restart: on-failure
+    restart: unless-stopped
     ports:
       - ${TYPESENSE_PORT}:${TYPESENSE_PORT}
     volumes:
@@ -61,7 +62,7 @@ services:
       --default-bucket  
 
   baikal-postgres:
-    image: postgres:18
+    image: postgres:18-bookworm
     restart: unless-stopped
     environment:
       POSTGRES_USER: baikal
@@ -78,7 +79,7 @@ services:
       -c work_mem=4MB
 
   postgres:
-    image: postgres:18
+    image: postgres:18-bookworm
     container_name: app-postgres
     restart: unless-stopped
     environment:
@@ -102,7 +103,7 @@ services:
       -c work_mem=4MB
 
   migrate:
-    image: postgres:18
+    image: postgres:18-bookworm
     depends_on:
       - postgres
     environment:
@@ -114,6 +115,6 @@ services:
       POSTGRES_DB: ${POSTGRES_DB}
       PGDATABASE: postgres
     volumes:
-      - ../init:/scripts
+      - ./init:/scripts
     entrypoint: [ "/bin/bash", "/scripts/db-bootstrap.sh" ]
     restart: "no"

--- a/db/docker-compose.yml
+++ b/db/docker-compose.yml
@@ -23,6 +23,7 @@ services:
         condition: service_healthy
   redis:
     image: redis:8.2.2
+    restart: unless-stopped
     command: [ "redis-server", "--appendonly", "yes", "--stop-writes-on-bgsave-error","no", "--requirepass", "${REDIS_PASSWORD}" ]
     healthcheck:
       test: [ "CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "PING" ]
@@ -45,7 +46,7 @@ services:
 
   typesense:
     image: typesense/typesense:29.0
-    restart: on-failure
+    restart: unless-stopped
     ports:
       - ${TYPESENSE_PORT}:${TYPESENSE_PORT}
     volumes:


### PR DESCRIPTION
## Summary

Fixes #566.

Production incident: a host-level Docker daemon/VM restart (outside our control) stopped all containers cleanly via SIGTERM. Most came back on their own, but `redis` and `typesense` didn't, which took the app down (Redis backs sessions/queues; nothing works without it).

Root cause: in both `db/docker-compose.yml` and `db/docker-compose.dev.yml`, `redis` had **no restart policy at all** (defaults to `no`), and `typesense` was `restart: on-failure`. Neither restarts a container after a clean stop (exit 0) — `on-failure` only triggers on a non-zero exit. Every other service in the stack (`postgres`, `garage`, `dav`) was already `unless-stopped`.

## Fix

- Changed `redis` and `typesense` to `restart: unless-stopped` in both compose files, matching the rest of the stack. Verified by restarting the Docker daemon twice locally — everything comes back unattended both times now.
- `db/docker-compose.dev.yml`'s `migrate` service mounted `../init:/scripts`, which resolves to the repo root's (nonexistent) `init/` since the compose file lives in `db/` — fixed to `./init:/scripts` (half of #546).
- Pinned `postgres:18` → `postgres:18-bookworm` in the dev compose file to match `db/docker-compose.yml` and avoid an Alpine/Debian image drift between the two.

## Not in scope here

`db/postgres/init.sql` and `db/garage/garage.toml` (the other half of #546) are gitignored entirely (`db/postgres`, `db/garage` in `.gitignore`) rather than missing — deciding whether to carve out exceptions and commit them (they only contain a placeholder password, no real secrets) is a separate call, left for #546.

## Test plan

- [x] Restarted the Docker daemon twice locally with the full `db/docker-compose.dev.yml` stack up — `redis` and `typesense` both came back unattended both times (previously required a manual `docker start`).