### PR TITLE
feat: allow disabling local (email/password) login

### DIFF
--- a/apps/docs/content/docs/installation.mdx
+++ b/apps/docs/content/docs/installation.mdx
@@ -118,6 +118,22 @@ email, raw EML files, or attachments, and it does not delete existing Drive
 data. Set the value back to `false` and restart the web container to restore the
 Drive interface.
 
+### Optional: disable local login
+
+For SSO-only deployments, you can hide the email/password login form and reject
+local login attempts server-side:
+
+```bash
+DISABLE_LOCAL_LOGIN=true
+```
+
+Configure at least one Google or generic OIDC provider before enabling this
+option. Otherwise, the login page will report that no login methods are
+available. Restart the web container after changing the value.
+
+This setting does not change signup availability. Use `DISABLE_SIGNUP=true`
+separately when local account registration should also be disabled.
+
 ---
 
 ✅ Once you are all set with your environment variables you are now ready to run

--- a/apps/web/components/auth/login-form.tsx
+++ b/apps/web/components/auth/login-form.tsx
@@ -8,6 +8,7 @@ import Form from "next/form";
 import Link from "next/link";
 import type * as React from "react";
 import { useActionState } from "react";
+import { useSiteFeatures } from "@/components/providers/site-features-provider";
 import {
 	Card,
 	CardContent,
@@ -34,6 +35,8 @@ export function LoginForm({
 		genericName?: string;
 	};
 } & { dict: Dictionary }) {
+	const { localLogin } = useSiteFeatures();
+	const oidcEnabled = Boolean(oidc?.googleEnabled || oidc?.genericEnabled);
 	const [formState, formAction, isPending] = useActionState<
 		FormState,
 		FormData
@@ -44,7 +47,7 @@ export function LoginForm({
 			<Card>
 				<CardHeader className="text-center">
 					<CardTitle className="text-xl">{dict.auth.welcomeBack}</CardTitle>
-					{(oidc?.googleEnabled || oidc?.genericEnabled) && (
+					{oidcEnabled && (
 						<CardDescription>
 							{dict.auth.loginWithExistingAccount}
 						</CardDescription>
@@ -74,14 +77,16 @@ export function LoginForm({
 							{oidc?.genericName || "SSO"}
 						</Button>
 					)}
-					{!oidc?.googleEnabled && !oidc?.genericEnabled && (
+					{!oidcEnabled && (
 						<div className={"text-sm text-center"}>
-							{dict.auth.noOidcEnabled}
+							{localLogin
+								? dict.auth.noOidcEnabled
+								: dict.auth.noLoginMethodsEnabled}
 						</div>
 					)}
 				</CardHeader>
 
-				<CardContent>
+				<CardContent hidden={!localLogin}>
 					<Form action={formAction}>
 						<input type="hidden" name="locale" value={dict.locale} />
 						<div className="grid gap-6">

--- a/apps/web/lib/actions/auth.ts
+++ b/apps/web/lib/actions/auth.ts
@@ -13,6 +13,7 @@ import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { getRedis } from "@/lib/actions/get-redis";
 import { updateWorkSpaceContext } from "@/lib/actions/workspace";
+import { SITE_FEATURES } from "@/lib/site-features";
 import { withLocale } from "@/lib/utils";
 
 const initProviders = async (userId: string, workspaceId: string) => {
@@ -144,6 +145,13 @@ export async function login(
 	_prev: FormState,
 	formData: FormData,
 ): Promise<FormState> {
+	if (!SITE_FEATURES.localLogin) {
+		return {
+			success: false,
+			error: "auth.localLoginDisabled",
+		};
+	}
+
 	const { email, password, locale } = decode(formData) as {
 		email: string;
 		password: string;

--- a/apps/web/lib/dictionaries/en/actions.json
+++ b/apps/web/lib/dictionaries/en/actions.json
@@ -5,7 +5,8 @@
 		"loggedIn": "Logged in!",
 		"accountAlreadyExists": "An account with this email already exists",
 		"welcome": "Welcome!",
-		"signupDisabled": "Signup is currently disabled. Please contact your administrator."
+		"signupDisabled": "Signup is currently disabled. Please contact your administrator.",
+		"localLoginDisabled": "Local login is currently disabled. Please use SSO to sign in."
 	},
 	"contacts": {
 		"noDefaultAddressBook": "No default address book found for user."

--- a/apps/web/lib/dictionaries/en/auth.json
+++ b/apps/web/lib/dictionaries/en/auth.json
@@ -13,6 +13,7 @@
 	"continueWith": "Continue with",
 	"workspaceName": "Workspace Name",
 	"noOidcEnabled": "No third-party authentication methods are currently enabled.",
+	"noLoginMethodsEnabled": "No login methods are currently enabled. Please contact your administrator.",
 	"loginWithGoogle": "Login with Google",
 	"loginWithProviderPrefix": "Login with ",
 	"signupWithGoogle": "Signup with Google",

--- a/apps/web/lib/dictionaries/pt-BR/actions.json
+++ b/apps/web/lib/dictionaries/pt-BR/actions.json
@@ -5,7 +5,8 @@
 		"loggedIn": "Login realizado!",
 		"accountAlreadyExists": "Já existe uma conta com este e-mail",
 		"welcome": "Bem-vindo!",
-		"signupDisabled": "O cadastro está desativado no momento. Entre em contato com o administrador."
+		"signupDisabled": "O cadastro está desativado no momento. Entre em contato com o administrador.",
+		"localLoginDisabled": "O login local está desativado no momento. Use o SSO para entrar."
 	},
 	"contacts": {
 		"noDefaultAddressBook": "Nenhum catálogo de endereços padrão encontrado para o usuário."

--- a/apps/web/lib/dictionaries/pt-BR/auth.json
+++ b/apps/web/lib/dictionaries/pt-BR/auth.json
@@ -13,6 +13,7 @@
 	"continueWith": "Continuar com",
 	"workspaceName": "Nome do workspace",
 	"noOidcEnabled": "Nenhum método de autenticação de terceiros está habilitado no momento.",
+	"noLoginMethodsEnabled": "Nenhum método de login está habilitado no momento. Entre em contato com o administrador.",
 	"loginWithGoogle": "Entrar com o Google",
 	"loginWithProviderPrefix": "Entrar com ",
 	"signupWithGoogle": "Cadastrar com o Google",

--- a/apps/web/lib/site-features.ts
+++ b/apps/web/lib/site-features.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 export const SITE_FEATURES = {
 	drive: process.env.DISABLE_DRIVE !== "true",
+	localLogin: process.env.DISABLE_LOCAL_LOGIN !== "true",
 } as const;
 
 export type SiteFeatures = typeof SITE_FEATURES;

--- a/db/example.develop.env
+++ b/db/example.develop.env
@@ -6,6 +6,10 @@ NITRO_PORT=3001
 # Mail storage, attachments, and existing Drive data are not affected.
 DISABLE_DRIVE=false
 
+# Disable email/password login for SSO-only deployments.
+# Configure at least one OIDC provider before enabling this option.
+DISABLE_LOCAL_LOGIN=false
+
 #LOCAL_TUNNEL_URL=https://your-ngrok-tunnel-url.ngrok-free.app
 
 REDIS_PASSWORD=replace_with_your_redis_password

--- a/db/example.env
+++ b/db/example.env
@@ -6,6 +6,10 @@ NITRO_PORT=3001
 # Mail storage, attachments, and existing Drive data are not affected.
 DISABLE_DRIVE=false
 
+# Disable email/password login for SSO-only deployments.
+# Configure at least one OIDC provider before enabling this option.
+DISABLE_LOCAL_LOGIN=false
+
 #LOCAL_TUNNEL_URL=https://your-ngrok-tunnel-url.ngrok-free.app
 
 REDIS_PASSWORD=replace_with_your_redis_password


### PR DESCRIPTION
Fixes #513
Supersedes #515

## Summary

Updates the original local-login feature from #515 for the current codebase and preserves the original commit author.

Self-hosted SSO-only deployments can set `DISABLE_LOCAL_LOGIN=true` to hide email/password login while keeping configured OIDC providers available. Direct calls to the local login server action are rejected as well.

## Changes

- centralizes availability as `SITE_FEATURES.localLogin`
- hides the email/password form and signup link when local login is disabled
- keeps Google and generic OIDC login options available
- rejects local login attempts server-side before credential or database work
- adds localized empty/error states for English and Portuguese
- documents the flag in both example env files and the installation guide
- keeps signup control independent through `DISABLE_SIGNUP`

## Attribution

This is based on the implementation by @areacli in #515. The original commit author is preserved; this PR only rebases and adapts the change to the current architecture and repository conventions.

## Verification

- `pnpm exec biome check` on changed TypeScript and JSON files
- `pnpm check:locales`
- `pnpm --prefix apps/web exec tsc --noEmit`
- `pnpm build:develop`
- `pnpm --prefix apps/docs build`
- `git diff --check`
