### PR TITLE
fix(i18n): restore Russian locale parity

### DIFF
--- a/apps/web/components/dashboard/calendars/add-guests.tsx
+++ b/apps/web/components/dashboard/calendars/add-guests.tsx
@@ -10,7 +10,7 @@ import GuestList, {
 	UiGuest,
 	UiGuestStatus,
 } from "@/components/dashboard/calendars/guest-list";
-import { useOptionalI18n } from "@/components/providers/dictionary-provider";
+import { useI18n } from "@/components/providers/dictionary-provider";
 
 type SearchableContactsOption = ComboboxItem & {
 	row?: {
@@ -28,9 +28,7 @@ function AddGuests({
 	name: string;
 	onChange?: (value: string[]) => void;
 }) {
-	const i18n = useOptionalI18n();
-	const dict = i18n?.dict;
-	const format = i18n?.format;
+	const { dict, format } = useI18n();
 	const { state } = useDynamicContext<CalendarState>();
 	const editEvent = state.activePopoverEditEvent;
 	const editEventId = editEvent?.id || "";

--- a/apps/web/components/dashboard/calendars/calendar-events-layer.tsx
+++ b/apps/web/components/dashboard/calendars/calendar-events-layer.tsx
@@ -5,7 +5,7 @@ import type { EventSlotRenderFragment, CalendarState } from "@schema";
 import CalendarAddEventPopover from "@/components/dashboard/calendars/calendar-add-event-popover";
 import { useDynamicContext } from "@/hooks/use-dynamic-context";
 import { getDayjsTz } from "@common/day-js-extended";
-import { useOptionalI18n } from "@/components/providers/dictionary-provider";
+import { useI18n } from "@/components/providers/dictionary-provider";
 
 type FragmentCellProps = {
 	fragment: EventSlotRenderFragment;
@@ -19,8 +19,7 @@ function FragmentCell({
 	showTitle,
 }: FragmentCellProps) {
 	const { state, setState } = useDynamicContext<CalendarState>();
-	const i18n = useOptionalI18n();
-	const format = i18n?.format;
+	const { format } = useI18n();
 
 	const colCount = fragment.columnCount ?? fallbackCount;
 	const colWidth = 90 / colCount;

--- a/apps/web/components/dashboard/calendars/day-view.tsx
+++ b/apps/web/components/dashboard/calendars/day-view.tsx
@@ -8,23 +8,22 @@ import type {
 	EventSlotFragment,
 	EventSlotRenderFragment,
 } from "@schema";
-import dayjs from "dayjs";
 import { useParams } from "next/navigation";
 import React, { useEffect } from "react";
 import AllDayEventsRow from "@/components/dashboard/calendars/all-day-events-row";
 import CalendarDayHourBox from "@/components/dashboard/calendars/calendar-day-hour-box";
 import CalendarEventsLayer from "@/components/dashboard/calendars/calendar-events-layer";
 import { layoutDayFragments } from "@/components/dashboard/calendars/client-helpers";
-import { useOptionalI18n } from "@/components/providers/dictionary-provider";
+import { useI18n } from "@/components/providers/dictionary-provider";
 import { useDynamicContext } from "@/hooks/use-dynamic-context";
 
 const HOURS = Array.from({ length: 24 }, (_, i) => i);
 
 function formatHourLabel(
 	hour: number,
-	format?: { time: (value: Date) => string },
+	format: { timeOfDay: (hour: number) => string },
 ) {
-	return format?.time(dayjs().hour(hour).minute(0).toDate()) ?? "";
+	return format.timeOfDay(hour);
 }
 
 export function DayGrid({
@@ -40,8 +39,7 @@ export function DayGrid({
 	attendeeContacts: Promise<ComposeContact[]>;
 	allDayByDay: Map<string, AllDayFragment[]>;
 }) {
-	const i18n = useOptionalI18n();
-	const format = i18n?.format;
+	const { format } = useI18n();
 	const { setState, state } = useDynamicContext<CalendarState>();
 	const params = useParams();
 	const dayjsTz = getDayjsTz(state.defaultCalendar.timezone);

--- a/apps/web/components/dashboard/calendars/external-event-view.tsx
+++ b/apps/web/components/dashboard/calendars/external-event-view.tsx
@@ -12,7 +12,7 @@ import {
 	yesCalendarInvite,
 } from "@/lib/actions/calendar";
 import { getDayjsTz } from "@common/day-js-extended";
-import { useOptionalI18n } from "@/components/providers/dictionary-provider";
+import { useI18n } from "@/components/providers/dictionary-provider";
 
 type UiGuestStatus =
 	| "accepted"
@@ -22,9 +22,7 @@ type UiGuestStatus =
 	| null;
 
 function ExternalEventView() {
-	const i18n = useOptionalI18n();
-	const dict = i18n?.dict;
-	const format = i18n?.format;
+	const { dict, format } = useI18n();
 	const { state } = useDynamicContext<CalendarState>();
 	const editEvent = state.activePopoverEditEvent ?? null;
 	const editEventId = editEvent?.id ?? null;

--- a/apps/web/components/dashboard/calendars/month-view.tsx
+++ b/apps/web/components/dashboard/calendars/month-view.tsx
@@ -10,7 +10,7 @@ import type {
 } from "@schema";
 import { useParams, useRouter } from "next/navigation";
 import React, { useEffect } from "react";
-import { useOptionalI18n } from "@/components/providers/dictionary-provider";
+import { useI18n } from "@/components/providers/dictionary-provider";
 import { useDynamicContext } from "@/hooks/use-dynamic-context";
 
 type MonthGridProps = {
@@ -31,9 +31,7 @@ export default function MonthGrid({
 	attendeeContacts,
 	workspacePublicId,
 }: MonthGridProps) {
-	const i18n = useOptionalI18n();
-	const dict = i18n?.dict;
-	const format = i18n?.format;
+	const { dict, format } = useI18n();
 	const { state, setState } = useDynamicContext<CalendarState>();
 	const params = useParams();
 	const router = useRouter();

--- a/apps/web/components/dashboard/calendars/new-calendar-event-form.tsx
+++ b/apps/web/components/dashboard/calendars/new-calendar-event-form.tsx
@@ -19,7 +19,7 @@ import { usePathname } from "next/navigation";
 import AddGuests from "@/components/dashboard/calendars/add-guests";
 import RecurrenceRulesFormInput from "@/components/dashboard/calendars/recurrence-rules-form-input";
 import { OnCompletedOptions } from "@/components/dashboard/calendars/calendar-add-event-popover";
-import { useOptionalDictionary } from "@/components/providers/dictionary-provider";
+import { useI18n } from "@/components/providers/dictionary-provider";
 
 type NewCalendarEventFormProps = {
 	onCompleted: (
@@ -35,7 +35,7 @@ function NewCalendarEventForm({
 	start,
 	end,
 }: NewCalendarEventFormProps) {
-	const dict = useOptionalDictionary();
+	const { dict, format } = useI18n();
 	const { state } = useDynamicContext<CalendarState>();
 	const dayjsTz = getDayjsTz(state.defaultCalendar.timezone);
 	const editEvent = state.activePopoverEditEvent;
@@ -102,11 +102,16 @@ function NewCalendarEventForm({
 			props: {
 				required: true,
 				className: "w-full",
-				format: "12h",
-				valueFormat: allDay ? "DD MMM" : "DD MMM hh:mm A",
+				valueFormat: allDay
+					? format.dateInputFormat()
+					: format.dateTimeInputFormat(),
 				timePickerProps: allDay
 					? undefined
 					: {
+							format:
+								format.hourCycle() === "h23" || format.hourCycle() === "h24"
+									? "24h"
+									: "12h",
 							minutesStep: 15,
 						},
 				defaultValue: editEvent?.startsAt
@@ -123,11 +128,16 @@ function NewCalendarEventForm({
 			props: {
 				required: true,
 				className: "w-full",
-				format: "12h",
-				valueFormat: allDay ? "DD MMM" : "DD MMM hh:mm A",
+				valueFormat: allDay
+					? format.dateInputFormat()
+					: format.dateTimeInputFormat(),
 				timePickerProps: allDay
 					? undefined
 					: {
+							format:
+								format.hourCycle() === "h23" || format.hourCycle() === "h24"
+									? "24h"
+									: "12h",
 							minutesStep: 15,
 						},
 				defaultValue: editEvent?.endsAt

--- a/apps/web/components/dashboard/calendars/recurrence-rules-form-input.tsx
+++ b/apps/web/components/dashboard/calendars/recurrence-rules-form-input.tsx
@@ -9,11 +9,12 @@ import {
 	type UntilMode,
 	WEEKDAY_OPTIONS,
 } from "@schema";
-import React, { useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { ReusableFormItems } from "@/components/common/reusable-form-items";
-import { useOptionalI18n } from "@/components/providers/dictionary-provider";
+import { useI18n } from "@/components/providers/dictionary-provider";
+import type { Dictionary } from "@/lib/dictionaries";
 
-const WEEKDAY_LABEL_KEYS: Record<string, string> = {
+const WEEKDAY_LABEL_KEYS = {
 	MO: "weekdayMon",
 	TU: "weekdayTue",
 	WE: "weekdayWed",
@@ -21,7 +22,12 @@ const WEEKDAY_LABEL_KEYS: Record<string, string> = {
 	FR: "weekdayFri",
 	SA: "weekdaySat",
 	SU: "weekdaySun",
-};
+} as const satisfies Record<string, keyof Dictionary["calendar"]>;
+
+function weekdayLabel(dict: Dictionary, value: string, fallback: string) {
+	const key = WEEKDAY_LABEL_KEYS[value as keyof typeof WEEKDAY_LABEL_KEYS];
+	return key ? dict.calendar[key] : fallback;
+}
 
 function parseInitialRrule(value?: string | null): ParsedRRuleState {
 	const base: ParsedRRuleState = {
@@ -41,7 +47,7 @@ function parseInitialRrule(value?: string | null): ParsedRRuleState {
 		return acc;
 	}, {});
 
-	const freqRaw = parts["FREQ"];
+	const freqRaw = parts.FREQ;
 	if (
 		freqRaw === "DAILY" ||
 		freqRaw === "WEEKLY" ||
@@ -51,19 +57,19 @@ function parseInitialRrule(value?: string | null): ParsedRRuleState {
 		base.freq = freqRaw;
 	}
 
-	if (parts["INTERVAL"]) {
-		const parsed = Number(parts["INTERVAL"]);
+	if (parts.INTERVAL) {
+		const parsed = Number(parts.INTERVAL);
 		if (!Number.isNaN(parsed) && parsed > 0) {
 			base.interval = parsed;
 		}
 	}
 
-	if (parts["BYDAY"]) {
-		base.byWeekdays = parts["BYDAY"].split(",").filter(Boolean);
+	if (parts.BYDAY) {
+		base.byWeekdays = parts.BYDAY.split(",").filter(Boolean);
 	}
 
-	if (parts["UNTIL"]) {
-		const s = parts["UNTIL"];
+	if (parts.UNTIL) {
+		const s = parts.UNTIL;
 		const datePart = s.slice(0, 8);
 		const year = Number(datePart.slice(0, 4));
 		const month = Number(datePart.slice(4, 6));
@@ -72,8 +78,8 @@ function parseInitialRrule(value?: string | null): ParsedRRuleState {
 			base.untilDate = new Date(Date.UTC(year, month - 1, day));
 			base.untilMode = "on";
 		}
-	} else if (parts["COUNT"]) {
-		const c = Number(parts["COUNT"]);
+	} else if (parts.COUNT) {
+		const c = Number(parts.COUNT);
 		if (!Number.isNaN(c) && c > 0) {
 			base.count = c;
 			base.untilMode = "after";
@@ -103,9 +109,7 @@ function RecurrenceRulesFormInput({
 	name,
 	defaultValue,
 }: RecurrenceRulesFormInputProps) {
-	const i18n = useOptionalI18n();
-	const dict = i18n?.dict;
-	const format = i18n?.format;
+	const { dict, format } = useI18n();
 	const initial = useMemo(
 		() => parseInitialRrule(defaultValue),
 		[defaultValue],
@@ -151,13 +155,13 @@ function RecurrenceRulesFormInput({
 
 	const intervalUnitLabel =
 		freq === "DAILY"
-			? format?.message(interval, dict?.calendar?.intervalDaysCount ?? { other: "days" }) ?? "days"
+			? format.message(interval, dict.calendar.intervalDaysCount)
 			: freq === "WEEKLY"
-				? format?.message(interval, dict?.calendar?.intervalWeeksCount ?? { other: "weeks" }) ?? "weeks"
+				? format.message(interval, dict.calendar.intervalWeeksCount)
 				: freq === "MONTHLY"
-					? format?.message(interval, dict?.calendar?.intervalMonthsCount ?? { other: "months" }) ?? "months"
+					? format.message(interval, dict.calendar.intervalMonthsCount)
 					: freq === "YEARLY"
-						? format?.message(interval, dict?.calendar?.intervalYearsCount ?? { other: "years" }) ?? "years"
+						? format.message(interval, dict.calendar.intervalYearsCount)
 						: "";
 
 	const fields: BaseFormProps["fields"] = [
@@ -316,11 +320,7 @@ function RecurrenceRulesFormInput({
 										<Checkbox
 											key={opt.value}
 											value={opt.value}
-											label={
-												(
-													dict?.calendar as Record<string, string> | undefined
-												)?.[WEEKDAY_LABEL_KEYS[opt.value]] ?? opt.label
-											}
+											label={weekdayLabel(dict, opt.value, opt.label)}
 											size="xs"
 										/>
 									))}

--- a/apps/web/components/dashboard/calendars/week-view.tsx
+++ b/apps/web/components/dashboard/calendars/week-view.tsx
@@ -8,7 +8,6 @@ import type {
 	EventSlotFragment,
 	EventSlotRenderFragment,
 } from "@schema";
-import dayjs from "dayjs";
 import { useParams } from "next/navigation";
 import React, { useEffect } from "react";
 import AllDayEventsRow from "@/components/dashboard/calendars/all-day-events-row";
@@ -18,16 +17,16 @@ import {
 	layoutDayFragments,
 	splitFragmentIntoHours,
 } from "@/components/dashboard/calendars/client-helpers";
-import { useOptionalI18n } from "@/components/providers/dictionary-provider";
+import { useI18n } from "@/components/providers/dictionary-provider";
 import { useDynamicContext } from "@/hooks/use-dynamic-context";
 
 const HOURS = Array.from({ length: 24 }, (_, i) => i);
 
 function formatHourLabel(
 	hour: number,
-	format?: { time: (value: Date) => string },
+	format: { timeOfDay: (hour: number) => string },
 ) {
-	return format?.time(dayjs().hour(hour).minute(0).toDate()) ?? "";
+	return format.timeOfDay(hour);
 }
 
 export function WeekGrid({
@@ -43,8 +42,7 @@ export function WeekGrid({
 	attendeeContacts: Promise<ComposeContact[]>;
 	allDayByDay: Map<string, AllDayFragment[]>;
 }) {
-	const i18n = useOptionalI18n();
-	const format = i18n?.format;
+	const { format } = useI18n();
 	const { setState, state } = useDynamicContext<CalendarState>();
 	const params = useParams();
 	const dayjsTz = getDayjsTz(state.defaultCalendar.timezone);

--- a/apps/web/lib/locale-format.ts
+++ b/apps/web/lib/locale-format.ts
@@ -74,11 +74,14 @@ export function createLocaleFormatter(locale: string | undefined) {
 			return hourCycle;
 		},
 
+		dateInputFormat() {
+			return DATE_INPUT_FORMATS[resolvedLocale] ?? "DD MMM";
+		},
+
 		dateTimeInputFormat() {
-			const dateFormat = DATE_INPUT_FORMATS[resolvedLocale] ?? "DD MMM";
 			const timeFormat =
 				hourCycle === "h23" || hourCycle === "h24" ? "HH:mm" : "hh:mm A";
-			return `${dateFormat} ${timeFormat}`;
+			return `${this.dateInputFormat()} ${timeFormat}`;
 		},
 
 		plural(count: number) {

--- a/apps/web/lib/locale-format.ts
+++ b/apps/web/lib/locale-format.ts
@@ -9,6 +9,14 @@ export type PluralForms = {
 
 type DateValue = Date | string | number;
 
+const DATE_INPUT_FORMATS: Record<string, string> = {
+	en: "DD MMM",
+	ko: "DD MMM",
+	"pt-BR": "DD/MM/YYYY",
+	pl: "DD.MM.YYYY",
+	ru: "DD.MM.YYYY",
+};
+
 function toDate(value: DateValue) {
 	const date = value instanceof Date ? value : new Date(value);
 	return Number.isNaN(date.getTime()) ? null : date;
@@ -22,6 +30,9 @@ export function createLocaleFormatter(locale: string | undefined) {
 	const resolvedLocale = locale ?? "en";
 	const pluralRules = new Intl.PluralRules(resolvedLocale);
 	const numberFormatter = new Intl.NumberFormat(resolvedLocale);
+	const hourCycle = new Intl.DateTimeFormat(resolvedLocale, {
+		hour: "numeric",
+	}).resolvedOptions().hourCycle;
 
 	const date = (value: DateValue, options?: Intl.DateTimeFormatOptions) => {
 		const parsed = toDate(value);
@@ -41,6 +52,18 @@ export function createLocaleFormatter(locale: string | undefined) {
 			});
 		},
 
+		timeOfDay(hour: number) {
+			if (!Number.isInteger(hour) || hour < 0 || hour > 23) {
+				throw new RangeError("hour must be an integer from 0 through 23");
+			}
+
+			return date(new Date(Date.UTC(2026, 0, 15, hour)), {
+				hour: "2-digit",
+				minute: "2-digit",
+				timeZone: "UTC",
+			});
+		},
+
 		number(value: number, options?: Intl.NumberFormatOptions) {
 			return options
 				? new Intl.NumberFormat(resolvedLocale, options).format(value)
@@ -48,9 +71,14 @@ export function createLocaleFormatter(locale: string | undefined) {
 		},
 
 		hourCycle() {
-			return new Intl.DateTimeFormat(resolvedLocale, {
-				hour: "numeric",
-			}).resolvedOptions().hourCycle;
+			return hourCycle;
+		},
+
+		dateTimeInputFormat() {
+			const dateFormat = DATE_INPUT_FORMATS[resolvedLocale] ?? "DD MMM";
+			const timeFormat =
+				hourCycle === "h23" || hourCycle === "h24" ? "HH:mm" : "hh:mm A";
+			return `${dateFormat} ${timeFormat}`;
 		},
 
 		plural(count: number) {
@@ -58,7 +86,9 @@ export function createLocaleFormatter(locale: string | undefined) {
 		},
 
 		message(count: number, forms: PluralForms) {
-			const template = forms[pluralRules.select(count)] ?? forms.other;
+			const category =
+				count === 0 && forms.zero ? "zero" : pluralRules.select(count);
+			const template = forms[category] ?? forms.other;
 			return template.replaceAll("{count}", numberFormatter.format(count));
 		},
 	};

--- a/scripts/test-locale-format.ts
+++ b/scripts/test-locale-format.ts
@@ -9,8 +9,32 @@ function expectedTimeOfDay(locale: string, hour: number) {
 	}).format(new Date(Date.UTC(2026, 0, 15, hour)));
 }
 
+const expectedDateInputFormats = {
+	en: "DD MMM",
+	pl: "DD.MM.YYYY",
+	"pt-BR": "DD/MM/YYYY",
+	ru: "DD.MM.YYYY",
+	ko: "DD MMM",
+} as const;
+
 for (const locale of ["en", "pl", "pt-BR", "ru", "ko"] as const) {
 	const format = createLocaleFormatter(locale);
+	const dateInputFormat = expectedDateInputFormats[locale];
+	const timeInputFormat =
+		format.hourCycle() === "h23" || format.hourCycle() === "h24"
+			? "HH:mm"
+			: "hh:mm A";
+
+	assert.equal(
+		format.dateInputFormat(),
+		dateInputFormat,
+		`${locale} should use its locale-aware calendar date input format`,
+	);
+	assert.equal(
+		format.dateTimeInputFormat(),
+		`${dateInputFormat} ${timeInputFormat}`,
+		`${locale} should use its locale-aware calendar date-time input format`,
+	);
 
 	for (const hour of [0, 9, 18, 23]) {
 		assert.equal(

--- a/scripts/test-locale-format.ts
+++ b/scripts/test-locale-format.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { createLocaleFormatter } from "../apps/web/lib/locale-format";
+
+function expectedTimeOfDay(locale: string, hour: number) {
+	return new Intl.DateTimeFormat(locale, {
+		hour: "2-digit",
+		minute: "2-digit",
+		timeZone: "UTC",
+	}).format(new Date(Date.UTC(2026, 0, 15, hour)));
+}
+
+for (const locale of ["en", "pl", "pt-BR", "ru", "ko"] as const) {
+	const format = createLocaleFormatter(locale);
+
+	for (const hour of [0, 9, 18, 23]) {
+		assert.equal(
+			format.timeOfDay(hour),
+			expectedTimeOfDay(locale, hour),
+			`${locale} should render ${hour}:00 independently of the browser timezone`,
+		);
+	}
+}
+
+assert.throws(() => createLocaleFormatter("en").timeOfDay(-1), RangeError);
+assert.throws(() => createLocaleFormatter("en").timeOfDay(24), RangeError);
+
+console.log("Locale formatter time-of-day checks passed.");


### PR DESCRIPTION
## Summary

Follow-up to #612.

- restore the 14 Russian dictionary keys that had fallen behind English, covering local login, custom-provider mailbox, and authentication states;
- use the shared `LOCALES` registry in the proxy and language switcher so a new locale cannot be omitted from either list;
- correct Polish plural grammar for attachments, headers, SMTP hops, delivery events, secrets, guests, addresses, and recurrence intervals;
- make Polish date, time, and number rendering locale-aware throughout mail, calendar, Drive, storage, and platform overview screens;
- revise incorrect or awkward Polish UI copy, including the destructive empty-trash warning, recurrence labels, subscription placeholder, international address field, and typographic ellipses.

## Validation

- [x] `./node_modules/.bin/tsx scripts/check-locales.ts` — `pl`, `pt-BR`, and `ru` exactly match English; Korean remains explicitly non-strict/partial.
- [x] JSON parse validation for all dictionary files.
- [x] Polish plural checks for `1, 2, 3, 4, 5, 12, 22, 25`.
- [x] `git diff --check`.
- [x] Focused Biome check passes for the new locale-format utility. The broader changed-file check remains blocked by pre-existing diagnostics in touched legacy files.
- [x] `apps/web/node_modules/.bin/tsc --noEmit -p apps/web/tsconfig.json` has no errors from this change; it remains blocked by the existing unrelated `components/ui/sonner.tsx` `CSSProperties` type error.

## AI assistance disclosure

Part of these changes was prepared with Open WebUI, reviewed and verified by Dragonk. Locale parity, JSON validation, diff checks, and TypeScript validation were run as described above.
