### PR TITLE
feat(mail): mailbox-scoped conversation threading

### DIFF
--- a/apps/web/app/[locale]/w/[wPublicId]/dashboard/(unified)/(mail)/mail/[identityPublicId]/[mailboxSlug]/@thread/(.)threads/[threadId]/page.tsx
+++ b/apps/web/app/[locale]/w/[wPublicId]/dashboard/(unified)/(mail)/mail/[identityPublicId]/[mailboxSlug]/@thread/(.)threads/[threadId]/page.tsx
@@ -29,12 +29,15 @@ async function ThreadContent({
 
 	const { threadId, identityPublicId, mailboxSlug } = await params;
 
-	const [{ activeMailbox, mailboxSync }, activeThread, workspacePublicId] =
-		await Promise.all([
-			fetchMailbox(identityPublicId, mailboxSlug),
-			fetchWebMailThreadDetail(threadId),
-			getWorkspacePublicId(),
-		]);
+	const { activeMailbox, mailboxSync } = await fetchMailbox(
+		identityPublicId,
+		mailboxSlug,
+	);
+
+	const [activeThread, workspacePublicId] = await Promise.all([
+		fetchWebMailThreadDetail(threadId, activeMailbox.id),
+		getWorkspacePublicId(),
+	]);
 
 	const { byMessageId } = await fetchThreadMailSubscriptions({
 		ownerId: activeMailbox.ownerId,

--- a/apps/web/app/[locale]/w/[wPublicId]/dashboard/(unified)/(mail)/mail/[identityPublicId]/[mailboxSlug]/threads/[threadId]/page.tsx
+++ b/apps/web/app/[locale]/w/[wPublicId]/dashboard/(unified)/(mail)/mail/[identityPublicId]/[mailboxSlug]/threads/[threadId]/page.tsx
@@ -23,12 +23,15 @@ async function Page({
 	}>;
 }) {
 	const { threadId, identityPublicId, mailboxSlug } = await params;
-	const [{ activeMailbox, mailboxSync }, activeThread, workspacePublicId] =
-		await Promise.all([
-			fetchMailbox(identityPublicId, mailboxSlug),
-			fetchWebMailThreadDetail(threadId),
-			getWorkspacePublicId(),
-		]);
+	const { activeMailbox, mailboxSync } = await fetchMailbox(
+		identityPublicId,
+		mailboxSlug,
+	);
+
+	const [activeThread, workspacePublicId] = await Promise.all([
+		fetchWebMailThreadDetail(threadId, activeMailbox.id),
+		getWorkspacePublicId(),
+	]);
 
 	const { byMessageId } = await fetchThreadMailSubscriptions({
 		ownerId: activeMailbox.ownerId,

--- a/apps/web/lib/actions/mailbox.ts
+++ b/apps/web/lib/actions/mailbox.ts
@@ -43,6 +43,7 @@ import { isSignedIn } from "@/lib/actions/auth";
 import slugify from "@sindresorhus/slugify";
 import { redirect } from "next/navigation";
 import { PAGE_SIZE } from "@common/mail-client";
+import { deduplicateThreadMessages } from "@common";
 import { getRedis } from "@/lib/actions/get-redis";
 import dayjs from "dayjs";
 import {fetchWorkspace} from "@/lib/actions/workspace";
@@ -630,9 +631,16 @@ export const backfillAccount = async (identityId: string, workspaceId: string) =
 	);
 };
 
-export const fetchWebMailThreadDetail = cache(async (threadId: string) => {
+export const fetchWebMailThreadDetail = cache(async (threadId: string, mailboxId: string) => {
 	const rls = await rlsClient();
 	const result = await rls(async (tx) => {
+		const [activeMailbox] = await tx
+			.select({ identityId: mailboxes.identityId })
+			.from(mailboxes)
+			.where(eq(mailboxes.id, mailboxId))
+			.limit(1);
+		if (!activeMailbox) return { thread: null, messages: [] };
+
 		const rows = await tx
 			.select({
 				thread: threads,
@@ -640,7 +648,8 @@ export const fetchWebMailThreadDetail = cache(async (threadId: string) => {
 			})
 			.from(threads)
 			.innerJoin(messages, eq(messages.threadId, threads.id))
-			.where(eq(threads.id, threadId))
+			.innerJoin(mailboxes, eq(messages.mailboxId, mailboxes.id))
+			.where(and(eq(threads.id, threadId), eq(mailboxes.identityId, activeMailbox.identityId)))
 			.orderBy(asc(sql`coalesce(${messages.date}, ${messages.createdAt})`));
 
 		if (rows.length === 0) {
@@ -651,7 +660,10 @@ export const fetchWebMailThreadDetail = cache(async (threadId: string) => {
 		}
 
 		const thread = rows[0].thread;
-		const msgs = rows.map((r) => r.message);
+		const msgs = deduplicateThreadMessages(
+			rows.map((r) => r.message),
+			mailboxId,
+		);
 		return { thread, messages: msgs };
 	});
 	return result;

--- a/apps/worker/lib/message-payload-parser.ts
+++ b/apps/worker/lib/message-payload-parser.ts
@@ -9,10 +9,16 @@ import {
 	MessageAttachmentCreate,
 	MessageAttachmentInsertSchema,
 	mailSubscriptions,
+	mailboxes,
 	workspaces,
 } from "@db";
-import { generateSnippet, upsertMailboxThreadItem } from "@common";
-import { randomUUID } from "crypto";
+import {
+	buildThreadingCandidates,
+	fallbackMessageId,
+	generateSnippet,
+	upsertMailboxThreadItem,
+} from "@common";
+import { randomUUID } from "node:crypto";
 import { and, desc, eq, inArray, sql } from "drizzle-orm";
 import { getRedis } from "../lib/get-redis";
 import {s3} from "../lib/create-s3-client";
@@ -140,21 +146,25 @@ function generateFileName(att: Attachment) {
 }
 
 export async function createOrInitializeThread(
-	parsed: ParsedMail & { ownerId: string, workspaceId: string },
+	parsed: ParsedMail & { ownerId: string; workspaceId: string; mailboxId: string },
 ) {
-	const { ownerId, workspaceId } = parsed;
-	const inReplyTo = parsed.inReplyTo?.trim() || null;
+	const { ownerId, workspaceId, mailboxId } = parsed;
+	const inReplyTo = parsed.inReplyTo ?? null;
 	const refs = Array.isArray(parsed.references)
 		? parsed.references
 		: parsed.references
 			? [parsed.references]
 			: [];
-	const candidates = Array.from(
-		new Set([inReplyTo, ...refs].filter(Boolean).map((s) => String(s))),
-	);
+	const candidates = buildThreadingCandidates(inReplyTo, refs);
 
 	return db.transaction(async (tx) => {
 		let existingThread = null;
+		const [mailbox] = await tx
+			.select({ identityId: mailboxes.identityId })
+			.from(mailboxes)
+			.where(eq(mailboxes.id, mailboxId))
+			.limit(1);
+		if (!mailbox) throw new Error(`Mailbox ${mailboxId} not found`);
 
 		if (candidates.length > 0) {
 			const parentMsgs = await tx
@@ -165,9 +175,11 @@ export async function createOrInitializeThread(
 					date: messages.date,
 				})
 				.from(messages)
+				.innerJoin(mailboxes, eq(messages.mailboxId, mailboxes.id))
 				.where(
 					and(
 						eq(messages.ownerId, ownerId),
+						eq(mailboxes.identityId, mailbox.identityId),
 						inArray(messages.messageId, candidates),
 					),
 				)
@@ -252,14 +264,7 @@ export async function parseAndStoreEmail(
 	const headers = parsed.headers as Map<string, any>;
 
 	const messageId =
-		parsed.messageId || String(headers.get("message-id") || "").trim();
-
-	if (!messageId) {
-		console.warn(
-			`[parseAndStoreEmail] Skipping message with no Message-ID (mailboxId=${mailboxId}, storageKey=${rawStorageKey})`,
-		);
-		return null;
-	}
+		parsed.messageId || String(headers.get("message-id") || "").trim() || fallbackMessageId(rawEmail);
 
 	/**
 	 * Important for IMAP replay / UIDVALIDITY recovery:
@@ -336,6 +341,7 @@ export async function parseAndStoreEmail(
 		...parsed,
 		ownerId,
 		workspaceId,
+		mailboxId,
 	});
 
 	const decoratedParsed = {

--- a/apps/worker/lib/message-payload-parser.ts
+++ b/apps/worker/lib/message-payload-parser.ts
@@ -16,6 +16,7 @@ import {
 	buildThreadingCandidates,
 	extractThreadingHeader,
 	fallbackMessageId,
+	parseThreadingReferences,
 	resolveMessageId,
 	selectThreadParent,
 	generateSnippet,
@@ -270,7 +271,7 @@ export async function parseAndStoreEmail(
 	const rawInReplyTo = extractThreadingHeader(rawEmail, "in-reply-to");
 	const rawReferences = extractThreadingHeader(rawEmail, "references");
 	const inReplyTo = rawInReplyTo ?? null;
-	const references = rawReferences ? [rawReferences] : [];
+	const references = parseThreadingReferences(rawReferences);
 	const messageId = resolveMessageId(rawEmail, parsed.messageId, String(headers.get("message-id") || ""));
 
 	/**

--- a/apps/worker/lib/message-payload-parser.ts
+++ b/apps/worker/lib/message-payload-parser.ts
@@ -15,7 +15,6 @@ import {
 import {
 	buildThreadingCandidates,
 	extractThreadingHeader,
-	fallbackMessageId,
 	parseThreadingReferences,
 	resolveMessageId,
 	selectThreadParent,

--- a/apps/worker/lib/message-payload-parser.ts
+++ b/apps/worker/lib/message-payload-parser.ts
@@ -14,12 +14,15 @@ import {
 } from "@db";
 import {
 	buildThreadingCandidates,
+	extractThreadingHeader,
 	fallbackMessageId,
+	resolveMessageId,
+	selectThreadParent,
 	generateSnippet,
 	upsertMailboxThreadItem,
 } from "@common";
 import { randomUUID } from "node:crypto";
-import { and, desc, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import { getRedis } from "../lib/get-redis";
 import {s3} from "../lib/create-s3-client";
 import {PutObjectCommand} from "@aws-sdk/client-s3";
@@ -182,13 +185,15 @@ export async function createOrInitializeThread(
 						eq(mailboxes.identityId, mailbox.identityId),
 						inArray(messages.messageId, candidates),
 					),
-				)
-				.orderBy(desc(messages.date ?? sql`now()`));
+				);
 
 			if (parentMsgs.length) {
-				const chosen = inReplyTo
-					? parentMsgs.find((m) => m.messageId === inReplyTo)
-					: parentMsgs[0];
+				const selectedId = selectThreadParent(
+					inReplyTo,
+					refs,
+					parentMsgs.map((message) => message.messageId),
+				);
+				const chosen = parentMsgs.find((m) => m.messageId === selectedId);
 
 				if (chosen?.threadId) {
 					const [t] = await tx
@@ -262,9 +267,11 @@ export async function parseAndStoreEmail(
 
 	const parsed = await simpleParser(rawEmail);
 	const headers = parsed.headers as Map<string, any>;
-
-	const messageId =
-		parsed.messageId || String(headers.get("message-id") || "").trim() || fallbackMessageId(rawEmail);
+	const rawInReplyTo = extractThreadingHeader(rawEmail, "in-reply-to");
+	const rawReferences = extractThreadingHeader(rawEmail, "references");
+	const inReplyTo = rawInReplyTo ?? null;
+	const references = rawReferences ? [rawReferences] : [];
+	const messageId = resolveMessageId(rawEmail, parsed.messageId, String(headers.get("message-id") || ""));
 
 	/**
 	 * Important for IMAP replay / UIDVALIDITY recovery:
@@ -339,6 +346,8 @@ export async function parseAndStoreEmail(
 
 	const thread = await createOrInitializeThread({
 		...parsed,
+		inReplyTo,
+		references,
 		ownerId,
 		workspaceId,
 		mailboxId,
@@ -346,6 +355,9 @@ export async function parseAndStoreEmail(
 
 	const decoratedParsed = {
 		...parsed,
+		messageId,
+		inReplyTo,
+		references: references.length ? references : null,
 		mailboxId,
 		workspaceId,
 		threadId: thread.id,
@@ -353,11 +365,6 @@ export async function parseAndStoreEmail(
 		headersJson: Object.fromEntries(parsed.headers as Map<string, any>),
 		hasAttachments: (parsed.attachments?.length ?? 0) > 0,
 		rawStorageKey,
-		references: Array.isArray(parsed.references)
-			? parsed.references
-			: parsed.references
-				? [parsed.references]
-				: null,
 		seen: false,
 		answered: false,
 		flagged: false,

--- a/apps/worker/lib/message-payload-parser.ts
+++ b/apps/worker/lib/message-payload-parser.ts
@@ -271,7 +271,9 @@ export async function parseAndStoreEmail(
 	const rawInReplyTo = extractThreadingHeader(rawEmail, "in-reply-to");
 	const rawReferences = extractThreadingHeader(rawEmail, "references");
 	const inReplyTo = rawInReplyTo ?? null;
-	const references = parseThreadingReferences(rawReferences);
+	const references = parseThreadingReferences(
+		rawReferences ? [rawReferences] : [],
+	);
 	const messageId = resolveMessageId(rawEmail, parsed.messageId, String(headers.get("message-id") || ""));
 
 	/**

--- a/apps/worker/server/plugins/send-mail.ts
+++ b/apps/worker/server/plugins/send-mail.ts
@@ -6,7 +6,11 @@ import {
 	MailComposeInput,
 } from "@schema";
 import { getMessageAddress, getMessageName } from "@common/mail-client";
-import { generateSnippet, upsertMailboxThreadItem } from "@common";
+import {
+	generateSnippet,
+	parseThreadingReferences,
+	upsertMailboxThreadItem,
+} from "@common";
 const serverConfig = getServerEnv();
 import { Worker } from "bullmq";
 import {
@@ -337,9 +341,11 @@ export default defineNitroPlugin(async (nitroApp) => {
 					? Array.from(
 						new Set(
 							[
-								...(Array.isArray(origRow.message.references)
-									? origRow.message.references
-									: []),
+								...parseThreadingReferences(
+									Array.isArray(origRow.message.references)
+										? origRow.message.references
+										: [],
+								),
 								origRow.message.messageId ?? null,
 							].filter(Boolean),
 						),

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -3,3 +3,5 @@ export * from "./redis-ops";
 export * from "./constants";
 export * from "./day-js-extended";
 export * from "./common-utils";
+
+export * from "./message-threading";

--- a/packages/common/src/message-threading.test.ts
+++ b/packages/common/src/message-threading.test.ts
@@ -3,8 +3,11 @@ import { test } from "node:test";
 import {
 	buildThreadingCandidates,
 	deduplicateThreadMessages,
+	extractThreadingHeader,
 	fallbackMessageId,
+	resolveMessageId,
 	normalizeMessageId,
+	selectThreadParent,
 } from "./message-threading";
 
 test("builds ordered unique candidates from reply and references", () => {
@@ -51,6 +54,127 @@ test("creates a deterministic fallback id for messages without Message-ID", () =
 	const raw = `From: sender@example.test\n\nhello`;
 	assert.equal(fallbackMessageId(raw), fallbackMessageId(raw));
 	assert.notEqual(fallbackMessageId(raw), fallbackMessageId(`${raw}!`));
+});
+
+test("extracts the complete References header before mailparser splits it", () => {
+	const raw = [
+		"From: sender@example.test",
+		"References: <good@example.test> junk <victim@example.test>",
+		"\t<folded@example.test>",
+		"Subject: test",
+		"",
+		"body",
+	].join("\r\n");
+
+	assert.equal(
+		extractThreadingHeader(raw, "references"),
+		"<good@example.test> junk <victim@example.test> <folded@example.test>",
+	);
+});
+
+test("does not consume a new header as part of a malformed folded header", () => {
+	const raw = [
+		"References: junk <victim@example.test>",
+		"X-Injected: <attacker@example.test>",
+		"\t<continued@example.test>",
+		"",
+	].join("\r\n");
+
+	assert.equal(
+		extractThreadingHeader(raw, "references"),
+		"junk <victim@example.test>",
+	);
+	assert.deepEqual(
+		buildThreadingCandidates(extractThreadingHeader(raw, "in-reply-to"), [
+			extractThreadingHeader(raw, "references"),
+		]),
+		[],
+	);
+});
+
+test("does not parse body text as a threading header", () => {
+	const raw = ["Subject: test", "", "References: <body@example.test>"].join(
+		"\r\n",
+	);
+
+	assert.equal(extractThreadingHeader(raw, "references"), null);
+});
+
+test("accepts legitimate folded threading headers through the raw header seam", () => {
+	const raw = [
+		"In-Reply-To: <reply@example.test>",
+		"References: <root@example.test>",
+		"\t<parent@example.test>",
+		"",
+	].join("\r\n");
+
+	assert.deepEqual(
+		buildThreadingCandidates(extractThreadingHeader(raw, "in-reply-to"), [
+			extractThreadingHeader(raw, "references"),
+		]),
+		["<reply@example.test>", "<root@example.test>", "<parent@example.test>"],
+	);
+});
+
+test("uses the fallback at storage when parsed Message-ID values are invalid", () => {
+	const raw = "Message-ID: <bad\\@example.com>\r\n\r\nbody";
+	const fallback = fallbackMessageId(raw);
+
+	assert.equal(
+		resolveMessageId(raw, "<bad\\@example.com>", "<also(comment)@example.com>"),
+		fallback,
+	);
+	assert.equal(
+		resolveMessageId(raw, "<valid@example.com>", "<bad\\@example.com>"),
+		"<valid@example.com>",
+	);
+});
+
+test("rejects message ids with invalid dot-atom punctuation", () => {
+	for (const value of [
+		"<.leading@example.com>",
+		"<trailing.@example.com>",
+		"<double..dot@example.com>",
+		"<user@.example.com>",
+		"<user@example..com>",
+		"<user@example.com.>",
+		"<user@example.com:25>",
+		"<user\\@example.com>",
+		"<user(comment)@example.com>",
+		"<user@example.com(comment)>",
+	]) {
+		assert.equal(normalizeMessageId(value), null, value);
+	}
+});
+
+test("selects the final References candidate when In-Reply-To is absent", () => {
+	assert.equal(
+		selectThreadParent(
+			null,
+			["<root@example.test>", "<parent@example.test>"],
+			["<parent@example.test>", "<root@example.test>"],
+		),
+		"<parent@example.test>",
+	);
+});
+
+test("prioritizes In-Reply-To and then scans References from final to earliest", () => {
+	assert.equal(
+		selectThreadParent(
+			"<reply@example.test>",
+			["<root@example.test>", "<parent@example.test>"],
+			["<root@example.test>", "<reply@example.test>", "<parent@example.test>"],
+		),
+		"<reply@example.test>",
+	);
+	assert.equal(
+		selectThreadParent(
+			null,
+			["<root@example.test>", "<parent@example.test>", "<latest@example.test>"],
+			["<root@example.test>", "<parent@example.test>", "<latest@example.test>"],
+		),
+		"<latest@example.test>",
+	);
 });
 
 test("deduplicates Inbox and Sent copies while preferring the active mailbox", () => {

--- a/packages/common/src/message-threading.test.ts
+++ b/packages/common/src/message-threading.test.ts
@@ -5,8 +5,9 @@ import {
 	deduplicateThreadMessages,
 	extractThreadingHeader,
 	fallbackMessageId,
-	resolveMessageId,
 	normalizeMessageId,
+	parseThreadingReferences,
+	resolveMessageId,
 	selectThreadParent,
 } from "./message-threading";
 
@@ -46,6 +47,19 @@ test("accepts a folded references header represented as one string", () => {
 		buildThreadingCandidates(null, [
 			"<root@example.test>\n <parent@example.test>",
 		]),
+		["<root@example.test>", "<parent@example.test>"],
+	);
+});
+
+test("normalizes a raw References header into stored message IDs", () => {
+	const raw = [
+		"References: <root@example.test>",
+		"	<parent@example.test>",
+		"",
+	].join("\r\n");
+
+	assert.deepEqual(
+		parseThreadingReferences(extractThreadingHeader(raw, "references")),
 		["<root@example.test>", "<parent@example.test>"],
 	);
 });

--- a/packages/common/src/message-threading.test.ts
+++ b/packages/common/src/message-threading.test.ts
@@ -179,6 +179,17 @@ test("selects the final References candidate when In-Reply-To is absent", () => 
 	);
 });
 
+test("uses valid message IDs from a multi-value In-Reply-To header", () => {
+	assert.equal(
+		selectThreadParent(
+			"<first@example.test> <reply@example.test>",
+			["<root@example.test>"],
+			["<reply@example.test>", "<root@example.test>"],
+		),
+		"<reply@example.test>",
+	);
+});
+
 test("prioritizes In-Reply-To and then scans References from final to earliest", () => {
 	assert.equal(
 		selectThreadParent(

--- a/packages/common/src/message-threading.test.ts
+++ b/packages/common/src/message-threading.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+	buildThreadingCandidates,
+	deduplicateThreadMessages,
+	fallbackMessageId,
+	normalizeMessageId,
+} from "./message-threading";
+
+test("builds ordered unique candidates from reply and references", () => {
+	assert.deepEqual(
+		buildThreadingCandidates(" <reply@example.test> ", [
+			"<root@example.test>",
+			"<reply@example.test>",
+			"<root@example.test>",
+		]),
+		["<reply@example.test>", "<root@example.test>"],
+	);
+});
+
+test("rejects malformed message ids instead of joining unrelated mail", () => {
+	assert.equal(normalizeMessageId("not-a-message-id"), null);
+	assert.deepEqual(
+		buildThreadingCandidates(" <reply@example.test> ", [
+			"broken",
+			"<root@example.test>",
+		]),
+		["<reply@example.test>", "<root@example.test>"],
+	);
+});
+
+test("accepts a folded references header represented as one string", () => {
+	assert.deepEqual(
+		buildThreadingCandidates(null, [
+			"<root@example.test>\n <parent@example.test>",
+		]),
+		["<root@example.test>", "<parent@example.test>"],
+	);
+});
+
+test("creates a deterministic fallback id for messages without Message-ID", () => {
+	const raw = `From: sender@example.test\n\nhello`;
+	assert.equal(fallbackMessageId(raw), fallbackMessageId(raw));
+	assert.notEqual(fallbackMessageId(raw), fallbackMessageId(`${raw}!`));
+});
+
+test("deduplicates Inbox and Sent copies while preferring the active mailbox", () => {
+	const inbox = {
+		id: "inbox-copy",
+		mailboxId: "inbox",
+		messageId: "<same@example.test>",
+	};
+	const sent = {
+		id: "sent-copy",
+		mailboxId: "sent",
+		messageId: "<same@example.test>",
+	};
+	assert.deepEqual(deduplicateThreadMessages([inbox, sent], "sent"), [sent]);
+});

--- a/packages/common/src/message-threading.test.ts
+++ b/packages/common/src/message-threading.test.ts
@@ -59,7 +59,14 @@ test("normalizes a raw References header into stored message IDs", () => {
 	].join("\r\n");
 
 	assert.deepEqual(
-		parseThreadingReferences(extractThreadingHeader(raw, "references")),
+		parseThreadingReferences([extractThreadingHeader(raw, "references")]),
+		["<root@example.test>", "<parent@example.test>"],
+	);
+});
+
+test("normalizes legacy stored References values before reply composition", () => {
+	assert.deepEqual(
+		parseThreadingReferences(["<root@example.test> <parent@example.test>"]),
 		["<root@example.test>", "<parent@example.test>"],
 	);
 });

--- a/packages/common/src/message-threading.test.ts
+++ b/packages/common/src/message-threading.test.ts
@@ -20,12 +20,21 @@ test("builds ordered unique candidates from reply and references", () => {
 
 test("rejects malformed message ids instead of joining unrelated mail", () => {
 	assert.equal(normalizeMessageId("not-a-message-id"), null);
+	assert.equal(normalizeMessageId("junk <victim@example.com> trailing"), null);
 	assert.deepEqual(
 		buildThreadingCandidates(" <reply@example.test> ", [
 			"broken",
 			"<root@example.test>",
+			"junk <victim@example.com> trailing",
 		]),
 		["<reply@example.test>", "<root@example.test>"],
+	);
+});
+
+test("rejects malformed References values containing embedded message ids", () => {
+	assert.deepEqual(
+		buildThreadingCandidates(null, ["prefix <victim@example.com> suffix"]),
+		[],
 	);
 });
 

--- a/packages/common/src/message-threading.ts
+++ b/packages/common/src/message-threading.ts
@@ -52,9 +52,9 @@ export function buildThreadingCandidates(
 }
 
 export function parseThreadingReferences(
-	value: string | null | undefined,
+	references: readonly (string | null | undefined)[],
 ): string[] {
-	return buildThreadingCandidates(null, value ? [value] : []);
+	return buildThreadingCandidates(null, references);
 }
 
 export function selectThreadParent(

--- a/packages/common/src/message-threading.ts
+++ b/packages/common/src/message-threading.ts
@@ -1,20 +1,19 @@
 import { createHash } from "node:crypto";
 
-const MESSAGE_ID_PATTERN = /<[^<>\s@]+@[^<>\s@]+>/g;
+const MESSAGE_ID_PATTERN = /^<[^<>\s@]+@[^<>\s@]+>$/;
 
 export function normalizeMessageId(
 	value: string | null | undefined,
 ): string | null {
 	const normalized = value?.trim();
 	if (!normalized) return null;
-	const matches = normalized.match(MESSAGE_ID_PATTERN);
-	return matches?.length === 1 && matches[0] === normalized ? matches[0] : null;
+	return MESSAGE_ID_PATTERN.test(normalized) ? normalized : null;
 }
 
 function extractMessageIds(value: string | null | undefined): string[] {
-	if (!value) return [];
-	const matches = value.match(MESSAGE_ID_PATTERN);
-	return matches ?? [];
+	if (!value?.trim()) return [];
+	const ids = value.trim().split(/\s+/).map(normalizeMessageId);
+	return ids.every((id): id is string => id !== null) ? ids : [];
 }
 
 export function buildThreadingCandidates(

--- a/packages/common/src/message-threading.ts
+++ b/packages/common/src/message-threading.ts
@@ -1,0 +1,44 @@
+import { createHash } from "node:crypto";
+
+const MESSAGE_ID_PATTERN = /<[^<>\s@]+@[^<>\s@]+>/g;
+
+export function normalizeMessageId(
+	value: string | null | undefined,
+): string | null {
+	const normalized = value?.trim();
+	if (!normalized) return null;
+	const matches = normalized.match(MESSAGE_ID_PATTERN);
+	return matches?.length === 1 && matches[0] === normalized ? matches[0] : null;
+}
+
+function extractMessageIds(value: string | null | undefined): string[] {
+	if (!value) return [];
+	const matches = value.match(MESSAGE_ID_PATTERN);
+	return matches ?? [];
+}
+
+export function buildThreadingCandidates(
+	inReplyTo: string | null | undefined,
+	references: readonly (string | null | undefined)[],
+): string[] {
+	return Array.from(
+		new Set([inReplyTo, ...references].flatMap(extractMessageIds)),
+	);
+}
+
+export function fallbackMessageId(rawEmail: string): string {
+	return `<kurrier-${createHash("sha256").update(rawEmail).digest("hex")}@invalid>`;
+}
+
+export function deduplicateThreadMessages<
+	T extends { messageId: string; mailboxId: string },
+>(messages: readonly T[], activeMailboxId: string): T[] {
+	const byMessageId = new Map<string, T>();
+	for (const message of messages) {
+		const current = byMessageId.get(message.messageId);
+		if (!current || message.mailboxId === activeMailboxId) {
+			byMessageId.set(message.messageId, message);
+		}
+	}
+	return Array.from(byMessageId.values());
+}

--- a/packages/common/src/message-threading.ts
+++ b/packages/common/src/message-threading.ts
@@ -1,13 +1,39 @@
 import { createHash } from "node:crypto";
 
-const MESSAGE_ID_PATTERN = /^<[^<>\s@]+@[^<>\s@]+>$/;
+const ATOM = "[-A-Za-z0-9!#$%&'*+/=?^_`{|}~]+";
+const DOT_ATOM = `${ATOM}(?:\\.${ATOM})*`;
+const MESSAGE_ID_PATTERN = new RegExp(`^<${DOT_ATOM}@${DOT_ATOM}>$`);
 
 export function normalizeMessageId(
 	value: string | null | undefined,
 ): string | null {
 	const normalized = value?.trim();
-	if (!normalized) return null;
+	if (!normalized || /[\s:\r\n]/.test(normalized)) return null;
 	return MESSAGE_ID_PATTERN.test(normalized) ? normalized : null;
+}
+
+export function extractThreadingHeader(
+	rawEmail: string,
+	headerName: string,
+): string | null {
+	const lines = rawEmail.split(/\r?\n/);
+	const escapedName = headerName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	const headerPattern = new RegExp(`^${escapedName}:\\s*(.*)$`, "i");
+	for (let index = 0; index < lines.length; index += 1) {
+		if (lines[index] === "") break;
+		const match = lines[index].match(headerPattern);
+		if (!match) continue;
+		const values = [match[1]];
+		while (
+			index + 1 < lines.length &&
+			(lines[index + 1].startsWith(" ") || lines[index + 1].startsWith("\t"))
+		) {
+			index += 1;
+			values.push(lines[index].trim());
+		}
+		return values.join(" ").trim();
+	}
+	return null;
 }
 
 function extractMessageIds(value: string | null | undefined): string[] {
@@ -22,6 +48,37 @@ export function buildThreadingCandidates(
 ): string[] {
 	return Array.from(
 		new Set([inReplyTo, ...references].flatMap(extractMessageIds)),
+	);
+}
+
+export function selectThreadParent(
+	inReplyTo: string | null | undefined,
+	references: readonly (string | null | undefined)[],
+	availableMessageIds: readonly string[],
+): string | null {
+	const replyCandidate = normalizeMessageId(inReplyTo);
+	const referenceCandidates = Array.from(
+		new Set(references.flatMap(extractMessageIds)),
+	).reverse();
+	const ordered = replyCandidate
+		? [
+				replyCandidate,
+				...referenceCandidates.filter((id) => id !== replyCandidate),
+			]
+		: referenceCandidates;
+	const available = new Set(availableMessageIds);
+	return ordered.find((candidate) => available.has(candidate)) ?? null;
+}
+
+export function resolveMessageId(
+	rawEmail: string,
+	parsedMessageId: string | null | undefined,
+	rawMessageId: string | null | undefined,
+): string {
+	return (
+		normalizeMessageId(parsedMessageId) ??
+		normalizeMessageId(rawMessageId) ??
+		fallbackMessageId(rawEmail)
 	);
 }
 

--- a/packages/common/src/message-threading.ts
+++ b/packages/common/src/message-threading.ts
@@ -51,6 +51,12 @@ export function buildThreadingCandidates(
 	);
 }
 
+export function parseThreadingReferences(
+	value: string | null | undefined,
+): string[] {
+	return buildThreadingCandidates(null, value ? [value] : []);
+}
+
 export function selectThreadParent(
 	inReplyTo: string | null | undefined,
 	references: readonly (string | null | undefined)[],

--- a/packages/common/src/message-threading.ts
+++ b/packages/common/src/message-threading.ts
@@ -62,16 +62,14 @@ export function selectThreadParent(
 	references: readonly (string | null | undefined)[],
 	availableMessageIds: readonly string[],
 ): string | null {
-	const replyCandidate = normalizeMessageId(inReplyTo);
+	const replyCandidates = Array.from(new Set(extractMessageIds(inReplyTo)));
 	const referenceCandidates = Array.from(
 		new Set(references.flatMap(extractMessageIds)),
 	).reverse();
-	const ordered = replyCandidate
-		? [
-				replyCandidate,
-				...referenceCandidates.filter((id) => id !== replyCandidate),
-			]
-		: referenceCandidates;
+	const ordered = [
+		...replyCandidates,
+		...referenceCandidates.filter((id) => !replyCandidates.includes(id)),
+	];
 	const available = new Set(availableMessageIds);
 	return ordered.find((candidate) => available.has(candidate)) ?? null;
 }


### PR DESCRIPTION
## Summary
- Resolve replies and References within the active mailbox account.
- Include Inbox/Sent copies in the conversation while deduplicating identical RFC messages.
- Use deterministic fallback IDs for missing Message-ID headers and ignore malformed threading tokens.
- Scope the conversation view to the active identity and render messages in chronological order.

## Tests
- `pnpm exec tsx --test packages/common/src/message-threading.test.ts`
- `pnpm --filter @kurrier/worker build`
- `pnpm --filter @kurrier/web exec tsc --noEmit`

## Caveats
- Web production build is blocked in this environment by missing rewrite environment variables; worker build succeeds with pre-existing duplicate-member warnings.

Closes #632