### PR TITLE
feat(mail): add Microsoft OAuth/XOAUTH2 mailbox connection

### DIFF
--- a/apps/docs/content/docs/providers/meta.json
+++ b/apps/docs/content/docs/providers/meta.json
@@ -1,5 +1,15 @@
 {
 	"title": "Configuring Providers",
 	"defaultOpen": true,
-	"pages": ["ses", "smtp", "mailgun", "postmark", "sendgrid", "gmail", "inbound", "jmap"]
+	"pages": [
+		"ses",
+		"smtp",
+		"mailgun",
+		"postmark",
+		"sendgrid",
+		"gmail",
+		"inbound",
+		"jmap",
+		"microsoft"
+	]
 }

--- a/apps/docs/content/docs/providers/microsoft.mdx
+++ b/apps/docs/content/docs/providers/microsoft.mdx
@@ -1,0 +1,22 @@
+---
+title: Microsoft 365 delegated OAuth
+---
+
+Kurrier supports delegated Microsoft 365 mail through IMAP and SMTP XOAUTH2. This MVP does not use Microsoft Graph.
+
+## Entra app registration
+
+Register a Web platform application in Microsoft Entra ID. Add the exact callback URL configured by Kurrier (`<WEB_URL>/api/oauth/microsoft/callback`) and grant delegated Microsoft Graph-free permissions:
+
+- `IMAP.AccessAsUser.All`
+- `SMTP.Send`
+- `offline_access`
+- `openid`, `profile`, and `email`
+
+Tenant administrators may need to grant consent, and IMAP/SMTP AUTH must be enabled for the mailbox and tenant. App-only credentials and password authentication are not supported by this flow.
+
+## Security and lifecycle
+
+The authorization-code flow uses PKCE and an opaque, single-use state value. Access and refresh tokens must be stored through Kurrier's encrypted secret store; never put client secrets or tokens in source control. Refresh responses may rotate the refresh token, so the replacement must overwrite the stored value. Expired, revoked, consent-blocked, or policy-blocked authorization requires reconnecting the mailbox.
+
+XOAUTH2 sends the access token to both IMAP and SMTP. Kurrier refreshes tokens before expiry and reports the provider error when Microsoft or the tenant disables the protocol.

--- a/apps/web/app/[locale]/w/[wPublicId]/dashboard/(unified)/(platform)/platform/providers/page.tsx
+++ b/apps/web/app/[locale]/w/[wPublicId]/dashboard/(unified)/(platform)/platform/providers/page.tsx
@@ -5,6 +5,7 @@ import CustomEmailProviderCard from "@/components/dashboard/providers/custom-ema
 import GoogleCard from "@/components/dashboard/providers/google-card";
 import InboundCard from "@/components/dashboard/providers/inbound-card";
 import JmapCard from "@/components/dashboard/providers/jmap-card";
+import MicrosoftCard from "@/components/dashboard/providers/microsoft-card";
 import ProviderCardShell from "@/components/dashboard/providers/provider-card-shell";
 import SMTPCard from "@/components/dashboard/providers/smtp-card";
 import { Separator } from "@/components/ui/separator";
@@ -110,6 +111,9 @@ export default async function ProvidersPage({
 						/>
 						<InboundCard inboundIdentities={inboundIdentities} />
 						<JmapCard jmapAccounts={jmapAccounts} />
+						<MicrosoftCard
+							configured={Boolean(process.env.MICROSOFT_CLIENT_ID)}
+						/>
 					</div>
 				</Container>
 			</div>

--- a/apps/web/app/api/oauth/microsoft/callback/route.ts
+++ b/apps/web/app/api/oauth/microsoft/callback/route.ts
@@ -1,75 +1,89 @@
-import { cookies } from "next/headers";
-import { NextRequest, NextResponse } from "next/server";
-import { createSecret, smtpAccounts, smtpAccountSecrets } from "@db";
-import { rlsClient } from "@/lib/actions/clients";
-import { createEmailIdentity } from "@/lib/actions/email-identity";
-import { currentSession } from "@/lib/actions/auth";
+import crypto from "node:crypto";
+import {
+	createSecret,
+	identities,
+	secretsMeta,
+	smtpAccountSecrets,
+	smtpAccounts,
+} from "@db";
 import {
 	exchangeMicrosoftAuthorizationCode,
-	validateMicrosoftOAuthState,
 	MICROSOFT_MAIL_SCOPES,
+	type MicrosoftTokenSet,
+	validateMicrosoftOAuthState,
 } from "@providers";
-const fail = (id: string, msg: string) =>
-	NextResponse.redirect(
+import { eq } from "drizzle-orm";
+import { cookies } from "next/headers";
+import { type NextRequest, NextResponse } from "next/server";
+import { currentSession, isSignedIn } from "@/lib/actions/auth";
+import { getWorkspaceId, rlsClient } from "@/lib/actions/clients";
+import { createEmailIdentity } from "@/lib/actions/email-identity";
+import { verifyMicrosoftIdToken } from "@/lib/oauth/microsoft-oidc";
+import { consumeMicrosoftOAuthTransaction } from "@/lib/oauth/microsoft-transaction";
+
+const fail = (id: string, code = "microsoft_oauth_failed") => {
+	const correlationId = crypto.randomUUID();
+	console.error("[MICROSOFT OAUTH CALLBACK FAILED]", { correlationId, code });
+	return NextResponse.redirect(
 		new URL(
-			`/w/${id}/dashboard/platform/providers?microsoft_error=${encodeURIComponent(msg)}`,
+			`/w/${id}/dashboard/platform/providers?microsoft_error=${code}&correlation_id=${correlationId}`,
 			process.env.WEB_URL,
 		),
 	);
-const claims = (token: string) => {
-	try {
-		return JSON.parse(
-			Buffer.from(token.split(".")[1], "base64url").toString(),
-		) as Record<string, unknown>;
-	} catch {
-		return {};
-	}
 };
+
 export async function GET(req: NextRequest) {
-	const c = await cookies(),
-		state = c.get("microsoft_provider_state")?.value,
-		verifier = c.get("microsoft_provider_code_verifier")?.value,
-		workspaceId = c.get("microsoft_provider_workspace_id")?.value,
-		publicId = c.get("microsoft_provider_workspace_public_id")?.value,
-		ownerId = c.get("microsoft_provider_owner_id")?.value;
-	if (!state || !verifier || !workspaceId || !publicId || !ownerId)
+	const c = await cookies();
+	const txId = c.get("microsoft_provider_tx")?.value;
+	const session = await currentSession();
+	const user = await isSignedIn();
+	if (!txId || !session || !user)
 		return NextResponse.redirect(new URL("/auth/login", process.env.WEB_URL));
+	const tx = await consumeMicrosoftOAuthTransaction(txId);
+	if (!tx || tx.userId !== user.id) return fail(tx?.publicId ?? "");
+	c.delete("microsoft_provider_tx");
 	if (
-		!validateMicrosoftOAuthState(state, req.nextUrl.searchParams.get("state"))
+		!validateMicrosoftOAuthState(
+			tx.state,
+			req.nextUrl.searchParams.get("state"),
+		)
 	)
-		return fail(publicId, "Microsoft OAuth state validation failed");
-	const err = req.nextUrl.searchParams.get("error");
-	if (err)
-		return fail(
-			publicId,
-			req.nextUrl.searchParams.get("error_description") ?? err,
-		);
+		return fail(tx.publicId, "microsoft_oauth_state_invalid");
+	if ((await getWorkspaceId()) !== tx.workspaceId)
+		return fail(tx.publicId, "microsoft_oauth_workspace_invalid");
+	const providerError = req.nextUrl.searchParams.get("error");
+	if (providerError) return fail(tx.publicId, "microsoft_oauth_denied");
 	const code = req.nextUrl.searchParams.get("code");
-	if (!code) return fail(publicId, "Microsoft authorization code missing");
-	let t;
+	if (!code) return fail(tx.publicId, "microsoft_oauth_code_missing");
+	const clientId = process.env.MICROSOFT_CLIENT_ID;
+	if (!clientId) return fail(tx.publicId, "microsoft_oauth_not_configured");
+	let token: MicrosoftTokenSet;
 	try {
-		t = await exchangeMicrosoftAuthorizationCode({
-			clientId: process.env.MICROSOFT_CLIENT_ID!,
+		token = await exchangeMicrosoftAuthorizationCode({
+			clientId,
 			clientSecret: process.env.MICROSOFT_CLIENT_SECRET,
 			code,
-			codeVerifier: verifier,
+			codeVerifier: tx.codeVerifier,
 			redirectUri: `${process.env.WEB_URL}/api/oauth/microsoft/callback`,
 			tenant: process.env.MICROSOFT_TENANT ?? "common",
 		});
-	} catch (e) {
-		return fail(
-			publicId,
-			e instanceof Error ? e.message : "Microsoft OAuth token exchange failed",
-		);
+	} catch {
+		return fail(tx.publicId, "microsoft_oauth_exchange_failed");
 	}
-	if (!t.refreshToken)
-		return fail(
-			publicId,
-			"Microsoft did not return a refresh token. Remove Kurrier access and reconnect.",
-		);
-	const p = claims(String((t as any).idToken ?? "")),
-		email = String(p.email ?? p.preferred_username ?? "").trim();
-	if (!email) return fail(publicId, "Microsoft account email missing");
+	if (!token.refreshToken || !token.idToken)
+		return fail(tx.publicId, "microsoft_oauth_identity_missing");
+	let claims: Awaited<ReturnType<typeof verifyMicrosoftIdToken>>;
+	try {
+		claims = await verifyMicrosoftIdToken({
+			token: token.idToken,
+			clientId,
+			nonce: tx.nonce,
+		});
+	} catch {
+		return fail(tx.publicId, "microsoft_oauth_identity_invalid");
+	}
+	const email = String(claims.email ?? claims.preferred_username ?? "").trim();
+	if (!email) return fail(tx.publicId, "microsoft_oauth_identity_missing");
 	const config = {
 		label: `Microsoft — ${email}`,
 		ulid: `microsoft-${email}`,
@@ -77,58 +91,75 @@ export async function GET(req: NextRequest) {
 		SMTP_PORT: "587",
 		SMTP_USERNAME: email,
 		SMTP_AUTH_METHOD: "xoauth2",
-		SMTP_ACCESS_TOKEN: t.accessToken,
-		SMTP_TOKEN_EXPIRES_AT: t.expiresAt.toISOString(),
+		SMTP_ACCESS_TOKEN: token.accessToken,
+		SMTP_TOKEN_EXPIRES_AT: token.expiresAt.toISOString(),
 		SMTP_SECURE: "false",
 		IMAP_HOST: "outlook.office365.com",
 		IMAP_PORT: "993",
 		IMAP_USERNAME: email,
 		IMAP_AUTH_METHOD: "xoauth2",
-		IMAP_ACCESS_TOKEN: t.accessToken,
-		IMAP_TOKEN_EXPIRES_AT: t.expiresAt.toISOString(),
+		IMAP_ACCESS_TOKEN: token.accessToken,
+		IMAP_TOKEN_EXPIRES_AT: token.expiresAt.toISOString(),
 		IMAP_SECURE: "true",
-		MICROSOFT_REFRESH_TOKEN: t.refreshToken,
+		MICROSOFT_REFRESH_TOKEN: token.refreshToken,
 		MICROSOFT_TENANT: process.env.MICROSOFT_TENANT ?? "common",
 		MICROSOFT_CLIENT_ID: process.env.MICROSOFT_CLIENT_ID,
 		MICROSOFT_SCOPES: MICROSOFT_MAIL_SCOPES.join(" "),
 	};
-	const secret = await createSecret(await currentSession(), workspaceId, {
+	let secretId: string | undefined;
+	let accountId: string | undefined;
+	try {
+		const secret = await createSecret(session, tx.workspaceId, {
 			name: config.ulid,
 			value: JSON.stringify(config),
 			description: "Microsoft OAuth IMAP/SMTP tokens",
 			managedBy: "user",
-		}),
-		rls = await rlsClient();
-	const accountRows: any = await rls((tx: any) =>
-		tx.insert(smtpAccounts).values({ ownerId, workspaceId }).returning(),
-	);
-	const account = accountRows[0];
-	await rls((tx: any) =>
-		tx
-			.insert(smtpAccountSecrets)
-			.values({ accountId: account.id, secretId: secret.id, workspaceId }),
-	);
-	const identity = await createEmailIdentity({
-		email,
-		displayName: String(p.name ?? email),
-		smtpAccountId: account.id,
-	});
-	if (!identity.success)
-		return fail(
-			publicId,
-			identity.error ?? "Microsoft mailbox could not be created",
+		});
+		secretId = secret.id;
+		const rls = await rlsClient();
+		const [account] = await rls((db) =>
+			db
+				.insert(smtpAccounts)
+				.values({ ownerId: tx.userId, workspaceId: tx.workspaceId })
+				.returning(),
 		);
-	for (const k of [
-		"state",
-		"code_verifier",
-		"workspace_id",
-		"workspace_public_id",
-		"owner_id",
-	])
-		c.delete(`microsoft_provider_${k}`);
+		accountId = account.id;
+		await rls((db) =>
+			db.insert(smtpAccountSecrets).values({
+				accountId: account.id,
+				secretId: secret.id,
+				workspaceId: tx.workspaceId,
+			}),
+		);
+		const identity = await createEmailIdentity({
+			email,
+			displayName: String(claims.name ?? email),
+			smtpAccountId: account.id,
+		});
+		if (!identity.success) throw new Error("identity_creation_failed");
+	} catch {
+		const rls = await rlsClient();
+		const failedAccountId = accountId;
+		const failedSecretId = secretId;
+		if (failedAccountId)
+			await rls((db) =>
+				db
+					.delete(identities)
+					.where(eq(identities.smtpAccountId, failedAccountId)),
+			);
+		if (failedAccountId)
+			await rls((db) =>
+				db.delete(smtpAccounts).where(eq(smtpAccounts.id, failedAccountId)),
+			);
+		if (failedSecretId)
+			await rls((db) =>
+				db.delete(secretsMeta).where(eq(secretsMeta.id, failedSecretId)),
+			);
+		return fail(tx.publicId, "microsoft_oauth_persistence_failed");
+	}
 	return NextResponse.redirect(
 		new URL(
-			`/w/${publicId}/dashboard/platform/providers?connected=microsoft`,
+			`/w/${tx.publicId}/dashboard/platform/providers?connected=microsoft`,
 			process.env.WEB_URL,
 		),
 	);

--- a/apps/web/app/api/oauth/microsoft/callback/route.ts
+++ b/apps/web/app/api/oauth/microsoft/callback/route.ts
@@ -1,0 +1,135 @@
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+import { createSecret, smtpAccounts, smtpAccountSecrets } from "@db";
+import { rlsClient } from "@/lib/actions/clients";
+import { createEmailIdentity } from "@/lib/actions/email-identity";
+import { currentSession } from "@/lib/actions/auth";
+import {
+	exchangeMicrosoftAuthorizationCode,
+	validateMicrosoftOAuthState,
+	MICROSOFT_MAIL_SCOPES,
+} from "@providers";
+const fail = (id: string, msg: string) =>
+	NextResponse.redirect(
+		new URL(
+			`/w/${id}/dashboard/platform/providers?microsoft_error=${encodeURIComponent(msg)}`,
+			process.env.WEB_URL,
+		),
+	);
+const claims = (token: string) => {
+	try {
+		return JSON.parse(
+			Buffer.from(token.split(".")[1], "base64url").toString(),
+		) as Record<string, unknown>;
+	} catch {
+		return {};
+	}
+};
+export async function GET(req: NextRequest) {
+	const c = await cookies(),
+		state = c.get("microsoft_provider_state")?.value,
+		verifier = c.get("microsoft_provider_code_verifier")?.value,
+		workspaceId = c.get("microsoft_provider_workspace_id")?.value,
+		publicId = c.get("microsoft_provider_workspace_public_id")?.value,
+		ownerId = c.get("microsoft_provider_owner_id")?.value;
+	if (!state || !verifier || !workspaceId || !publicId || !ownerId)
+		return NextResponse.redirect(new URL("/auth/login", process.env.WEB_URL));
+	if (
+		!validateMicrosoftOAuthState(state, req.nextUrl.searchParams.get("state"))
+	)
+		return fail(publicId, "Microsoft OAuth state validation failed");
+	const err = req.nextUrl.searchParams.get("error");
+	if (err)
+		return fail(
+			publicId,
+			req.nextUrl.searchParams.get("error_description") ?? err,
+		);
+	const code = req.nextUrl.searchParams.get("code");
+	if (!code) return fail(publicId, "Microsoft authorization code missing");
+	let t;
+	try {
+		t = await exchangeMicrosoftAuthorizationCode({
+			clientId: process.env.MICROSOFT_CLIENT_ID!,
+			clientSecret: process.env.MICROSOFT_CLIENT_SECRET,
+			code,
+			codeVerifier: verifier,
+			redirectUri: `${process.env.WEB_URL}/api/oauth/microsoft/callback`,
+			tenant: process.env.MICROSOFT_TENANT ?? "common",
+		});
+	} catch (e) {
+		return fail(
+			publicId,
+			e instanceof Error ? e.message : "Microsoft OAuth token exchange failed",
+		);
+	}
+	if (!t.refreshToken)
+		return fail(
+			publicId,
+			"Microsoft did not return a refresh token. Remove Kurrier access and reconnect.",
+		);
+	const p = claims(String((t as any).idToken ?? "")),
+		email = String(p.email ?? p.preferred_username ?? "").trim();
+	if (!email) return fail(publicId, "Microsoft account email missing");
+	const config = {
+		label: `Microsoft — ${email}`,
+		ulid: `microsoft-${email}`,
+		SMTP_HOST: "smtp.office365.com",
+		SMTP_PORT: "587",
+		SMTP_USERNAME: email,
+		SMTP_AUTH_METHOD: "xoauth2",
+		SMTP_ACCESS_TOKEN: t.accessToken,
+		SMTP_TOKEN_EXPIRES_AT: t.expiresAt.toISOString(),
+		SMTP_SECURE: "false",
+		IMAP_HOST: "outlook.office365.com",
+		IMAP_PORT: "993",
+		IMAP_USERNAME: email,
+		IMAP_AUTH_METHOD: "xoauth2",
+		IMAP_ACCESS_TOKEN: t.accessToken,
+		IMAP_TOKEN_EXPIRES_AT: t.expiresAt.toISOString(),
+		IMAP_SECURE: "true",
+		MICROSOFT_REFRESH_TOKEN: t.refreshToken,
+		MICROSOFT_TENANT: process.env.MICROSOFT_TENANT ?? "common",
+		MICROSOFT_CLIENT_ID: process.env.MICROSOFT_CLIENT_ID,
+		MICROSOFT_SCOPES: MICROSOFT_MAIL_SCOPES.join(" "),
+	};
+	const secret = await createSecret(await currentSession(), workspaceId, {
+			name: config.ulid,
+			value: JSON.stringify(config),
+			description: "Microsoft OAuth IMAP/SMTP tokens",
+			managedBy: "user",
+		}),
+		rls = await rlsClient();
+	const accountRows: any = await rls((tx: any) =>
+		tx.insert(smtpAccounts).values({ ownerId, workspaceId }).returning(),
+	);
+	const account = accountRows[0];
+	await rls((tx: any) =>
+		tx
+			.insert(smtpAccountSecrets)
+			.values({ accountId: account.id, secretId: secret.id, workspaceId }),
+	);
+	const identity = await createEmailIdentity({
+		email,
+		displayName: String(p.name ?? email),
+		smtpAccountId: account.id,
+	});
+	if (!identity.success)
+		return fail(
+			publicId,
+			identity.error ?? "Microsoft mailbox could not be created",
+		);
+	for (const k of [
+		"state",
+		"code_verifier",
+		"workspace_id",
+		"workspace_public_id",
+		"owner_id",
+	])
+		c.delete(`microsoft_provider_${k}`);
+	return NextResponse.redirect(
+		new URL(
+			`/w/${publicId}/dashboard/platform/providers?connected=microsoft`,
+			process.env.WEB_URL,
+		),
+	);
+}

--- a/apps/web/app/api/oauth/microsoft/callback/route.ts
+++ b/apps/web/app/api/oauth/microsoft/callback/route.ts
@@ -18,11 +18,15 @@ import { type NextRequest, NextResponse } from "next/server";
 import { currentSession, isSignedIn } from "@/lib/actions/auth";
 import { getWorkspaceId, rlsClient } from "@/lib/actions/clients";
 import { createEmailIdentity } from "@/lib/actions/email-identity";
+import { compensateMicrosoftOAuthResources } from "@/lib/oauth/microsoft-compensation";
 import { verifyMicrosoftIdToken } from "@/lib/oauth/microsoft-oidc";
 import { consumeMicrosoftOAuthTransaction } from "@/lib/oauth/microsoft-transaction";
 
-const fail = (id: string, code = "microsoft_oauth_failed") => {
-	const correlationId = crypto.randomUUID();
+const fail = (
+	id: string,
+	code = "microsoft_oauth_failed",
+	correlationId = crypto.randomUUID(),
+) => {
 	console.error("[MICROSOFT OAUTH CALLBACK FAILED]", { correlationId, code });
 	return NextResponse.redirect(
 		new URL(
@@ -138,24 +142,69 @@ export async function GET(req: NextRequest) {
 		});
 		if (!identity.success) throw new Error("identity_creation_failed");
 	} catch {
+		const correlationId = crypto.randomUUID();
 		const rls = await rlsClient();
 		const failedAccountId = accountId;
 		const failedSecretId = secretId;
-		if (failedAccountId)
-			await rls((db) =>
-				db
-					.delete(identities)
-					.where(eq(identities.smtpAccountId, failedAccountId)),
-			);
-		if (failedAccountId)
-			await rls((db) =>
-				db.delete(smtpAccounts).where(eq(smtpAccounts.id, failedAccountId)),
-			);
-		if (failedSecretId)
-			await rls((db) =>
-				db.delete(secretsMeta).where(eq(secretsMeta.id, failedSecretId)),
-			);
-		return fail(tx.publicId, "microsoft_oauth_persistence_failed");
+		await compensateMicrosoftOAuthResources(correlationId, [
+			...(failedAccountId
+				? [
+						{
+							resource: "identities",
+							cleanup: () =>
+								rls((db) =>
+									db
+										.delete(identities)
+										.where(eq(identities.smtpAccountId, failedAccountId)),
+								),
+						},
+					]
+				: []),
+			...(failedAccountId
+				? [
+						{
+							resource: "smtp_account_secrets",
+							cleanup: () =>
+								rls((db) =>
+									db
+										.delete(smtpAccountSecrets)
+										.where(eq(smtpAccountSecrets.accountId, failedAccountId)),
+								),
+						},
+					]
+				: []),
+			...(failedAccountId
+				? [
+						{
+							resource: "smtp_accounts",
+							cleanup: () =>
+								rls((db) =>
+									db
+										.delete(smtpAccounts)
+										.where(eq(smtpAccounts.id, failedAccountId)),
+								),
+						},
+					]
+				: []),
+			...(failedSecretId
+				? [
+						{
+							resource: "secrets_meta",
+							cleanup: () =>
+								rls((db) =>
+									db
+										.delete(secretsMeta)
+										.where(eq(secretsMeta.id, failedSecretId)),
+								),
+						},
+					]
+				: []),
+		]);
+		return fail(
+			tx.publicId,
+			"microsoft_oauth_persistence_failed",
+			correlationId,
+		);
 	}
 	return NextResponse.redirect(
 		new URL(

--- a/apps/web/app/api/oauth/microsoft/callback/route.ts
+++ b/apps/web/app/api/oauth/microsoft/callback/route.ts
@@ -94,6 +94,7 @@ export async function GET(req: NextRequest) {
 		...createMicrosoftCredentials({
 			email,
 			clientId,
+			clientSecret: process.env.MICROSOFT_CLIENT_SECRET,
 			tenant: process.env.MICROSOFT_TENANT ?? "common",
 			token,
 		}),

--- a/apps/web/app/api/oauth/microsoft/callback/route.ts
+++ b/apps/web/app/api/oauth/microsoft/callback/route.ts
@@ -7,8 +7,8 @@ import {
 	smtpAccounts,
 } from "@db";
 import {
+	createMicrosoftCredentials,
 	exchangeMicrosoftAuthorizationCode,
-	MICROSOFT_MAIL_SCOPES,
 	type MicrosoftTokenSet,
 	validateMicrosoftOAuthState,
 } from "@providers";
@@ -91,24 +91,12 @@ export async function GET(req: NextRequest) {
 	const config = {
 		label: `Microsoft — ${email}`,
 		ulid: `microsoft-${email}`,
-		SMTP_HOST: "smtp.office365.com",
-		SMTP_PORT: "587",
-		SMTP_USERNAME: email,
-		SMTP_AUTH_METHOD: "xoauth2",
-		SMTP_ACCESS_TOKEN: token.accessToken,
-		SMTP_TOKEN_EXPIRES_AT: token.expiresAt.toISOString(),
-		SMTP_SECURE: "false",
-		IMAP_HOST: "outlook.office365.com",
-		IMAP_PORT: "993",
-		IMAP_USERNAME: email,
-		IMAP_AUTH_METHOD: "xoauth2",
-		IMAP_ACCESS_TOKEN: token.accessToken,
-		IMAP_TOKEN_EXPIRES_AT: token.expiresAt.toISOString(),
-		IMAP_SECURE: "true",
-		MICROSOFT_REFRESH_TOKEN: token.refreshToken,
-		MICROSOFT_TENANT: process.env.MICROSOFT_TENANT ?? "common",
-		MICROSOFT_CLIENT_ID: process.env.MICROSOFT_CLIENT_ID,
-		MICROSOFT_SCOPES: MICROSOFT_MAIL_SCOPES.join(" "),
+		...createMicrosoftCredentials({
+			email,
+			clientId,
+			tenant: process.env.MICROSOFT_TENANT ?? "common",
+			token,
+		}),
 	};
 	let secretId: string | undefined;
 	let accountId: string | undefined;

--- a/apps/web/app/api/oauth/microsoft/callback/route.ts
+++ b/apps/web/app/api/oauth/microsoft/callback/route.ts
@@ -143,7 +143,6 @@ export async function GET(req: NextRequest) {
 		if (!identity.success) throw new Error("identity_creation_failed");
 	} catch {
 		const correlationId = crypto.randomUUID();
-		const rls = await rlsClient();
 		const failedAccountId = accountId;
 		const failedSecretId = secretId;
 		await compensateMicrosoftOAuthResources(correlationId, [
@@ -151,8 +150,8 @@ export async function GET(req: NextRequest) {
 				? [
 						{
 							resource: "identities",
-							cleanup: () =>
-								rls((db) =>
+							cleanup: async () =>
+								(await rlsClient())((db) =>
 									db
 										.delete(identities)
 										.where(eq(identities.smtpAccountId, failedAccountId)),
@@ -164,8 +163,8 @@ export async function GET(req: NextRequest) {
 				? [
 						{
 							resource: "smtp_account_secrets",
-							cleanup: () =>
-								rls((db) =>
+							cleanup: async () =>
+								(await rlsClient())((db) =>
 									db
 										.delete(smtpAccountSecrets)
 										.where(eq(smtpAccountSecrets.accountId, failedAccountId)),
@@ -177,8 +176,8 @@ export async function GET(req: NextRequest) {
 				? [
 						{
 							resource: "smtp_accounts",
-							cleanup: () =>
-								rls((db) =>
+							cleanup: async () =>
+								(await rlsClient())((db) =>
 									db
 										.delete(smtpAccounts)
 										.where(eq(smtpAccounts.id, failedAccountId)),
@@ -190,8 +189,8 @@ export async function GET(req: NextRequest) {
 				? [
 						{
 							resource: "secrets_meta",
-							cleanup: () =>
-								rls((db) =>
+							cleanup: async () =>
+								(await rlsClient())((db) =>
 									db
 										.delete(secretsMeta)
 										.where(eq(secretsMeta.id, failedSecretId)),

--- a/apps/web/app/api/oauth/microsoft/connect/route.ts
+++ b/apps/web/app/api/oauth/microsoft/connect/route.ts
@@ -1,12 +1,14 @@
-import { cookies } from "next/headers";
-import { NextResponse } from "next/server";
-import { isSignedIn } from "@/lib/actions/auth";
-import { getWorkspaceId, getWorkspacePublicId } from "@/lib/actions/clients";
+import crypto from "node:crypto";
 import {
 	buildMicrosoftAuthorizationUrl,
 	createMicrosoftOAuthState,
 } from "@providers";
-import crypto from "node:crypto";
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+import { isSignedIn } from "@/lib/actions/auth";
+import { getWorkspaceId, getWorkspacePublicId } from "@/lib/actions/clients";
+import { createMicrosoftOAuthTransaction } from "@/lib/oauth/microsoft-transaction";
+
 export async function GET() {
 	const user = await isSignedIn();
 	if (!user)
@@ -19,29 +21,28 @@ export async function GET() {
 				process.env.WEB_URL,
 			),
 		);
-	const workspaceId = await getWorkspaceId(),
-		publicId = await getWorkspacePublicId(),
-		{ state, codeVerifier } = createMicrosoftOAuthState();
+	const workspaceId = await getWorkspaceId();
+	const publicId = await getWorkspacePublicId();
+	const { state, codeVerifier, nonce } = createMicrosoftOAuthState();
 	const challenge = crypto
-			.createHash("sha256")
-			.update(codeVerifier)
-			.digest("base64url"),
-		store = await cookies();
-	const opts = {
+		.createHash("sha256")
+		.update(codeVerifier)
+		.digest("base64url");
+	const tx = await createMicrosoftOAuthTransaction({
+		userId: user.id,
+		workspaceId,
+		publicId,
+		codeVerifier,
+		nonce,
+	});
+	const store = await cookies();
+	store.set("microsoft_provider_tx", tx.id, {
 		httpOnly: true,
 		secure: process.env.NODE_ENV === "production",
-		sameSite: "lax" as const,
+		sameSite: "lax",
 		path: "/",
 		maxAge: 600,
-	};
-	for (const [k, v] of [
-		["state", state],
-		["code_verifier", codeVerifier],
-		["workspace_id", workspaceId],
-		["workspace_public_id", publicId],
-		["owner_id", user.id],
-	])
-		store.set(`microsoft_provider_${k}`, v, opts);
+	});
 	return NextResponse.redirect(
 		buildMicrosoftAuthorizationUrl({
 			clientId,
@@ -49,6 +50,7 @@ export async function GET() {
 			state,
 			codeChallenge: challenge,
 			tenant: process.env.MICROSOFT_TENANT ?? "common",
+			nonce,
 			loginHint: user.email,
 		}),
 	);

--- a/apps/web/app/api/oauth/microsoft/connect/route.ts
+++ b/apps/web/app/api/oauth/microsoft/connect/route.ts
@@ -32,6 +32,7 @@ export async function GET() {
 		userId: user.id,
 		workspaceId,
 		publicId,
+		state,
 		codeVerifier,
 		nonce,
 	});

--- a/apps/web/app/api/oauth/microsoft/connect/route.ts
+++ b/apps/web/app/api/oauth/microsoft/connect/route.ts
@@ -1,0 +1,55 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+import { isSignedIn } from "@/lib/actions/auth";
+import { getWorkspaceId, getWorkspacePublicId } from "@/lib/actions/clients";
+import {
+	buildMicrosoftAuthorizationUrl,
+	createMicrosoftOAuthState,
+} from "@providers";
+import crypto from "node:crypto";
+export async function GET() {
+	const user = await isSignedIn();
+	if (!user)
+		return NextResponse.redirect(new URL("/auth/login", process.env.WEB_URL));
+	const clientId = process.env.MICROSOFT_CLIENT_ID;
+	if (!clientId)
+		return NextResponse.redirect(
+			new URL(
+				"/auth/login?error=microsoft_oauth_not_configured",
+				process.env.WEB_URL,
+			),
+		);
+	const workspaceId = await getWorkspaceId(),
+		publicId = await getWorkspacePublicId(),
+		{ state, codeVerifier } = createMicrosoftOAuthState();
+	const challenge = crypto
+			.createHash("sha256")
+			.update(codeVerifier)
+			.digest("base64url"),
+		store = await cookies();
+	const opts = {
+		httpOnly: true,
+		secure: process.env.NODE_ENV === "production",
+		sameSite: "lax" as const,
+		path: "/",
+		maxAge: 600,
+	};
+	for (const [k, v] of [
+		["state", state],
+		["code_verifier", codeVerifier],
+		["workspace_id", workspaceId],
+		["workspace_public_id", publicId],
+		["owner_id", user.id],
+	])
+		store.set(`microsoft_provider_${k}`, v, opts);
+	return NextResponse.redirect(
+		buildMicrosoftAuthorizationUrl({
+			clientId,
+			redirectUri: `${process.env.WEB_URL}/api/oauth/microsoft/callback`,
+			state,
+			codeChallenge: challenge,
+			tenant: process.env.MICROSOFT_TENANT ?? "common",
+			loginHint: user.email,
+		}),
+	);
+}

--- a/apps/web/components/dashboard/providers/microsoft-card.tsx
+++ b/apps/web/components/dashboard/providers/microsoft-card.tsx
@@ -1,0 +1,26 @@
+"use client";
+import { Button } from "@mantine/core";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+export default function MicrosoftCard({ configured }: { configured: boolean }) {
+	return (
+		<Card className="shadow-none border-border">
+			<CardHeader>
+				<CardTitle>Microsoft 365</CardTitle>
+				<p className="text-sm text-muted-foreground">
+					Connect Outlook and Microsoft 365 mailboxes with delegated OAuth.
+				</p>
+			</CardHeader>
+			<CardContent>
+				{configured ? (
+					<Button component="a" href="/api/oauth/microsoft/connect">
+						Connect Microsoft mailbox
+					</Button>
+				) : (
+					<p className="text-sm text-muted-foreground">
+						Microsoft OAuth is not configured by your administrator.
+					</p>
+				)}
+			</CardContent>
+		</Card>
+	);
+}

--- a/apps/web/lib/actions/dashboard.ts
+++ b/apps/web/lib/actions/dashboard.ts
@@ -41,6 +41,7 @@ import { decode } from "decode-formdata";
 import { PgColumn, PgTable } from "drizzle-orm/pg-core";
 import {
 	createMailer,
+	loadMicrosoftCredentials,
 	createStore,
 	DomainIdentity, gmailClientForGoogleAccount,
 	VerifyResult,
@@ -322,6 +323,7 @@ export async function fetchDecryptedSecrets({
 			.select({
 				linkRow: linkTable,
 				metaId: secretsMeta.id,
+				encryptedValue: secretsMeta.encryptedValue,
 				provider: providers,
 				smtpAccount: smtpAccounts,
 			})
@@ -347,6 +349,7 @@ export async function fetchDecryptedSecrets({
 			const payload = {
 				linkRow: r.linkRow,
 				metaId,
+				encryptedValue: r.encryptedValue,
 				vault,
 				providerId: r.linkRow?.providerId,
 				accountId: r.linkRow?.accountId,
@@ -860,7 +863,38 @@ export const testSendingEmail = async (
 ) => {
 	return handleAction(async () => {
 		if (userIdentity?.smtp_accounts) {
-			const mailer = createMailer("smtp", decryptedSecrets);
+			let smtpCredentials = decryptedSecrets;
+			if (decryptedSecrets.provider === "microsoft") {
+				const [smtpSecret] = await fetchDecryptedSecrets({
+					linkTable: smtpAccountSecrets,
+					foreignCol: smtpAccountSecrets.accountId,
+					secretIdCol: smtpAccountSecrets.secretId,
+					parentId: String(userIdentity.smtp_accounts.id),
+				});
+				if (!smtpSecret) throw new Error("SMTP account secret not found");
+				const session = await currentSession();
+				const workspaceId = await getWorkspaceId();
+				smtpCredentials = await loadMicrosoftCredentials(smtpSecret.parsedSecret, {
+					key: smtpSecret.metaId,
+					distributed: true,
+					persist: async (next) => {
+						await updateSecret(session, workspaceId, smtpSecret.metaId, {
+							value: JSON.stringify(next),
+							expectedEncryptedValue: String(smtpSecret.encryptedValue),
+						});
+					},
+					load: async () => {
+						const [latest] = await fetchDecryptedSecrets({
+							linkTable: smtpAccountSecrets,
+							foreignCol: smtpAccountSecrets.accountId,
+							secretIdCol: smtpAccountSecrets.secretId,
+							parentId: String(userIdentity.smtp_accounts.id),
+						});
+						return latest?.parsedSecret ?? null;
+					},
+				});
+			}
+			const mailer = createMailer("smtp", smtpCredentials);
 
 			const ok = await mailer.sendTestEmail(userIdentity.identities.value, {
 				subject: "Test email from Kurrier",

--- a/apps/web/lib/actions/email-identity.ts
+++ b/apps/web/lib/actions/email-identity.ts
@@ -13,10 +13,8 @@ import {
 } from "@db";
 import {
 	createMailer,
-	isMicrosoftTokenExpired,
-	refreshMicrosoftAccessToken,
+	loadMicrosoftCredentials,
 	type VerifyResult,
-	withMicrosoftRefreshLock,
 } from "@providers";
 import { defaultImapQuota, type FormState, handleAction } from "@schema";
 import { eq } from "drizzle-orm";
@@ -97,68 +95,25 @@ export async function verifySMTPAccount(
 		const session = await currentSession();
 		const workspaceId = await getWorkspaceId();
 
-		if (
-			parsedVaultValues.provider === "microsoft" &&
-			parsedVaultValues.MICROSOFT_REFRESH_TOKEN &&
-			parsedVaultValues.SMTP_TOKEN_EXPIRES_AT &&
-			isMicrosoftTokenExpired(new Date(parsedVaultValues.SMTP_TOKEN_EXPIRES_AT))
-		) {
-			const refreshed = await withMicrosoftRefreshLock(
-				smtpSecret.metaId,
-				() =>
-					refreshMicrosoftAccessToken({
-						clientId: String(parsedVaultValues.MICROSOFT_CLIENT_ID),
-						refreshToken: String(parsedVaultValues.MICROSOFT_REFRESH_TOKEN),
-						tenant: String(parsedVaultValues.MICROSOFT_TENANT),
-					}),
-				async (next) => {
-					const nextValues = {
-						...parsedVaultValues,
-						SMTP_ACCESS_TOKEN: next.accessToken,
-						IMAP_ACCESS_TOKEN: next.accessToken,
-						MICROSOFT_REFRESH_TOKEN:
-							next.refreshToken ?? parsedVaultValues.MICROSOFT_REFRESH_TOKEN,
-						SMTP_TOKEN_EXPIRES_AT: next.expiresAt.toISOString(),
-						IMAP_TOKEN_EXPIRES_AT: next.expiresAt.toISOString(),
-					};
-					await updateSecret(session, workspaceId, smtpSecret.metaId, {
-						value: JSON.stringify(nextValues),
-					});
-					parsedVaultValues = nextValues;
-				},
-				async () => {
-					const [latest] = await fetchDecryptedSecrets({
-						linkTable: smtpAccountSecrets,
-						foreignCol: smtpAccountSecrets.accountId,
-						secretIdCol: smtpAccountSecrets.secretId,
-						parentId: smtpAccountId,
-					});
-					const values = latest?.parsedSecret;
-					if (
-						!values?.SMTP_ACCESS_TOKEN ||
-						!values.SMTP_TOKEN_EXPIRES_AT ||
-						isMicrosoftTokenExpired(new Date(values.SMTP_TOKEN_EXPIRES_AT))
-					)
-						return null;
-					return {
-						accessToken: String(values.SMTP_ACCESS_TOKEN),
-						refreshToken: String(values.MICROSOFT_REFRESH_TOKEN),
-						expiresAt: new Date(values.SMTP_TOKEN_EXPIRES_AT),
-						tokenType: "Bearer",
-					};
-				},
-				{ distributed: true },
-			);
-			parsedVaultValues = {
-				...parsedVaultValues,
-				SMTP_ACCESS_TOKEN: refreshed.accessToken,
-				IMAP_ACCESS_TOKEN: refreshed.accessToken,
-				MICROSOFT_REFRESH_TOKEN:
-					refreshed.refreshToken ?? parsedVaultValues.MICROSOFT_REFRESH_TOKEN,
-				SMTP_TOKEN_EXPIRES_AT: refreshed.expiresAt.toISOString(),
-				IMAP_TOKEN_EXPIRES_AT: refreshed.expiresAt.toISOString(),
-			};
-		}
+		parsedVaultValues = await loadMicrosoftCredentials(parsedVaultValues, {
+			key: smtpSecret.metaId,
+			distributed: true,
+			persist: async (next) => {
+				await updateSecret(session, workspaceId, smtpSecret.metaId, {
+					value: JSON.stringify(next),
+					expectedEncryptedValue: String(smtpSecret.encryptedValue),
+				});
+			},
+			load: async () => {
+				const [latest] = await fetchDecryptedSecrets({
+					linkTable: smtpAccountSecrets,
+					foreignCol: smtpAccountSecrets.accountId,
+					secretIdCol: smtpAccountSecrets.secretId,
+					parentId: smtpAccountId,
+				});
+				return latest?.parsedSecret ?? null;
+			},
+		});
 
 		const mailer = createMailer("smtp", parsedVaultValues);
 		const res = await mailer.verify(smtpAccountId);

--- a/apps/web/lib/actions/email-identity.ts
+++ b/apps/web/lib/actions/email-identity.ts
@@ -15,7 +15,7 @@ import {currentSession, isSignedIn} from "@/lib/actions/auth";
 import {getWorkspaceId, rlsClient} from "@/lib/actions/clients";
 import { checkDefaultWorkspaceIdentity } from "@/lib/actions/workspace";
 import {assignIdentityToAllWorkspaceMembers, fetchDecryptedSecrets, initializeMailboxes} from "@/lib/actions/dashboard";
-import {createMailer, VerifyResult} from "@providers";
+import {createMailer, VerifyResult, refreshMicrosoftAccessToken, isMicrosoftTokenExpired} from "@providers";
 import {eq} from "drizzle-orm";
 
 export type CreateEmailIdentityInput = {
@@ -82,9 +82,15 @@ export async function verifySMTPAccount(
             throw new Error("SMTP account secret not found");
         }
 
-        const parsedVaultValues = smtpSecret.parsedSecret;
+        let parsedVaultValues = smtpSecret.parsedSecret;
         const session = await currentSession();
         const workspaceId = await getWorkspaceId();
+
+        if (parsedVaultValues.provider === "microsoft" && parsedVaultValues.MICROSOFT_REFRESH_TOKEN && parsedVaultValues.SMTP_TOKEN_EXPIRES_AT && isMicrosoftTokenExpired(new Date(parsedVaultValues.SMTP_TOKEN_EXPIRES_AT))) {
+            const refreshed = await refreshMicrosoftAccessToken({ clientId: String(parsedVaultValues.MICROSOFT_CLIENT_ID), refreshToken: String(parsedVaultValues.MICROSOFT_REFRESH_TOKEN), tenant: String(parsedVaultValues.MICROSOFT_TENANT) });
+            parsedVaultValues = { ...parsedVaultValues, SMTP_ACCESS_TOKEN: refreshed.accessToken, IMAP_ACCESS_TOKEN: refreshed.accessToken, MICROSOFT_REFRESH_TOKEN: refreshed.refreshToken ?? parsedVaultValues.MICROSOFT_REFRESH_TOKEN, SMTP_TOKEN_EXPIRES_AT: refreshed.expiresAt.toISOString(), IMAP_TOKEN_EXPIRES_AT: refreshed.expiresAt.toISOString() };
+            await updateSecret(session, workspaceId, smtpSecret.metaId, { value: JSON.stringify(parsedVaultValues) });
+        }
 
         const mailer = createMailer("smtp", parsedVaultValues);
         const res = await mailer.verify(smtpAccountId);

--- a/apps/web/lib/actions/email-identity.ts
+++ b/apps/web/lib/actions/email-identity.ts
@@ -1,256 +1,315 @@
 "use server";
 
 import {
-    createSecret,
-    db, deleteSecretAdmin,
-    identities,
-    IdentityCreate,
-    IdentityInsertSchema, smtpAccounts, smtpAccountSecrets, updateSecret,
+	createSecret,
+	db,
+	deleteSecretAdmin,
+	type IdentityCreate,
+	IdentityInsertSchema,
+	identities,
+	smtpAccountSecrets,
+	smtpAccounts,
+	updateSecret,
 } from "@db";
 import {
-    defaultImapQuota,
-    FormState, handleAction,
-} from "@schema";
-import {currentSession, isSignedIn} from "@/lib/actions/auth";
-import {getWorkspaceId, rlsClient} from "@/lib/actions/clients";
+	createMailer,
+	isMicrosoftTokenExpired,
+	refreshMicrosoftAccessToken,
+	type VerifyResult,
+	withMicrosoftRefreshLock,
+} from "@providers";
+import { defaultImapQuota, type FormState, handleAction } from "@schema";
+import { eq } from "drizzle-orm";
+import { currentSession, isSignedIn } from "@/lib/actions/auth";
+import { getWorkspaceId, rlsClient } from "@/lib/actions/clients";
+import {
+	assignIdentityToAllWorkspaceMembers,
+	fetchDecryptedSecrets,
+	initializeMailboxes,
+} from "@/lib/actions/dashboard";
 import { checkDefaultWorkspaceIdentity } from "@/lib/actions/workspace";
-import {assignIdentityToAllWorkspaceMembers, fetchDecryptedSecrets, initializeMailboxes} from "@/lib/actions/dashboard";
-import {createMailer, VerifyResult, refreshMicrosoftAccessToken, isMicrosoftTokenExpired} from "@providers";
-import {eq} from "drizzle-orm";
 
 export type CreateEmailIdentityInput = {
-    email: string;
-    displayName?: string;
-    smtpAccountId: string;
-    dailyQuota?: number;
+	email: string;
+	displayName?: string;
+	smtpAccountId: string;
+	dailyQuota?: number;
 };
 
 export async function createEmailIdentity(
-    input: CreateEmailIdentityInput,
+	input: CreateEmailIdentityInput,
 ): Promise<FormState> {
-    const workspaceId = await getWorkspaceId();
-    const userId = String((await isSignedIn())?.id ?? "");
+	const workspaceId = await getWorkspaceId();
+	const userId = String((await isSignedIn())?.id ?? "");
 
-    if (!userId) {
-        return {
-            success: false,
-            error: "dashboard.notSignedIn",
-        };
-    }
+	if (!userId) {
+		return {
+			success: false,
+			error: "dashboard.notSignedIn",
+		};
+	}
 
-    const identityData = IdentityInsertSchema.parse({
-        workspaceId,
-        ownerId: userId,
-        kind: "email",
-        value: input.email,
-        displayName: input.displayName || input.email,
-        smtpAccountId: input.smtpAccountId,
-        sharedWithWorkspace: true,
-        metaData: {
-            dailyQuota: input.dailyQuota || defaultImapQuota,
-            sharedWithWorkspace: true,
-        },
-    });
+	const identityData = IdentityInsertSchema.parse({
+		workspaceId,
+		ownerId: userId,
+		kind: "email",
+		value: input.email,
+		displayName: input.displayName || input.email,
+		smtpAccountId: input.smtpAccountId,
+		sharedWithWorkspace: true,
+		metaData: {
+			dailyQuota: input.dailyQuota || defaultImapQuota,
+			sharedWithWorkspace: true,
+		},
+	});
 
-    const [identity] = await db
-        .insert(identities)
-        .values(identityData as IdentityCreate)
-        .returning();
+	const [identity] = await db
+		.insert(identities)
+		.values(identityData as IdentityCreate)
+		.returning();
 
-    await checkDefaultWorkspaceIdentity();
-    await assignIdentityToAllWorkspaceMembers(identity);
-    await initializeMailboxes(identity, userId, workspaceId);
+	await checkDefaultWorkspaceIdentity();
+	await assignIdentityToAllWorkspaceMembers(identity);
+	await initializeMailboxes(identity, userId, workspaceId);
 
-    return {
-        success: true,
-        message: "dashboard.addedNewIdentity",
-    };
+	return {
+		success: true,
+		message: "dashboard.addedNewIdentity",
+	};
 }
 
 export async function verifySMTPAccount(
-    smtpAccountId: string,
+	smtpAccountId: string,
 ): Promise<FormState<VerifyResult>> {
-    return handleAction(async () => {
-        const [smtpSecret] = await fetchDecryptedSecrets({
-            linkTable: smtpAccountSecrets,
-            foreignCol: smtpAccountSecrets.accountId,
-            secretIdCol: smtpAccountSecrets.secretId,
-            parentId: smtpAccountId,
-        });
+	return handleAction(async () => {
+		const [smtpSecret] = await fetchDecryptedSecrets({
+			linkTable: smtpAccountSecrets,
+			foreignCol: smtpAccountSecrets.accountId,
+			secretIdCol: smtpAccountSecrets.secretId,
+			parentId: smtpAccountId,
+		});
 
-        if (!smtpSecret) {
-            throw new Error("SMTP account secret not found");
-        }
+		if (!smtpSecret) {
+			throw new Error("SMTP account secret not found");
+		}
 
-        let parsedVaultValues = smtpSecret.parsedSecret;
-        const session = await currentSession();
-        const workspaceId = await getWorkspaceId();
+		let parsedVaultValues = smtpSecret.parsedSecret;
+		const session = await currentSession();
+		const workspaceId = await getWorkspaceId();
 
-        if (parsedVaultValues.provider === "microsoft" && parsedVaultValues.MICROSOFT_REFRESH_TOKEN && parsedVaultValues.SMTP_TOKEN_EXPIRES_AT && isMicrosoftTokenExpired(new Date(parsedVaultValues.SMTP_TOKEN_EXPIRES_AT))) {
-            const refreshed = await refreshMicrosoftAccessToken({ clientId: String(parsedVaultValues.MICROSOFT_CLIENT_ID), refreshToken: String(parsedVaultValues.MICROSOFT_REFRESH_TOKEN), tenant: String(parsedVaultValues.MICROSOFT_TENANT) });
-            parsedVaultValues = { ...parsedVaultValues, SMTP_ACCESS_TOKEN: refreshed.accessToken, IMAP_ACCESS_TOKEN: refreshed.accessToken, MICROSOFT_REFRESH_TOKEN: refreshed.refreshToken ?? parsedVaultValues.MICROSOFT_REFRESH_TOKEN, SMTP_TOKEN_EXPIRES_AT: refreshed.expiresAt.toISOString(), IMAP_TOKEN_EXPIRES_AT: refreshed.expiresAt.toISOString() };
-            await updateSecret(session, workspaceId, smtpSecret.metaId, { value: JSON.stringify(parsedVaultValues) });
-        }
+		if (
+			parsedVaultValues.provider === "microsoft" &&
+			parsedVaultValues.MICROSOFT_REFRESH_TOKEN &&
+			parsedVaultValues.SMTP_TOKEN_EXPIRES_AT &&
+			isMicrosoftTokenExpired(new Date(parsedVaultValues.SMTP_TOKEN_EXPIRES_AT))
+		) {
+			const refreshed = await withMicrosoftRefreshLock(
+				smtpSecret.metaId,
+				() =>
+					refreshMicrosoftAccessToken({
+						clientId: String(parsedVaultValues.MICROSOFT_CLIENT_ID),
+						refreshToken: String(parsedVaultValues.MICROSOFT_REFRESH_TOKEN),
+						tenant: String(parsedVaultValues.MICROSOFT_TENANT),
+					}),
+				async (next) => {
+					const nextValues = {
+						...parsedVaultValues,
+						SMTP_ACCESS_TOKEN: next.accessToken,
+						IMAP_ACCESS_TOKEN: next.accessToken,
+						MICROSOFT_REFRESH_TOKEN:
+							next.refreshToken ?? parsedVaultValues.MICROSOFT_REFRESH_TOKEN,
+						SMTP_TOKEN_EXPIRES_AT: next.expiresAt.toISOString(),
+						IMAP_TOKEN_EXPIRES_AT: next.expiresAt.toISOString(),
+					};
+					await updateSecret(session, workspaceId, smtpSecret.metaId, {
+						value: JSON.stringify(nextValues),
+					});
+					parsedVaultValues = nextValues;
+				},
+				async () => {
+					const [latest] = await fetchDecryptedSecrets({
+						linkTable: smtpAccountSecrets,
+						foreignCol: smtpAccountSecrets.accountId,
+						secretIdCol: smtpAccountSecrets.secretId,
+						parentId: smtpAccountId,
+					});
+					const values = latest?.parsedSecret;
+					if (
+						!values?.SMTP_ACCESS_TOKEN ||
+						!values.SMTP_TOKEN_EXPIRES_AT ||
+						isMicrosoftTokenExpired(new Date(values.SMTP_TOKEN_EXPIRES_AT))
+					)
+						return null;
+					return {
+						accessToken: String(values.SMTP_ACCESS_TOKEN),
+						refreshToken: String(values.MICROSOFT_REFRESH_TOKEN),
+						expiresAt: new Date(values.SMTP_TOKEN_EXPIRES_AT),
+						tokenType: "Bearer",
+					};
+				},
+				{ distributed: true },
+			);
+			parsedVaultValues = {
+				...parsedVaultValues,
+				SMTP_ACCESS_TOKEN: refreshed.accessToken,
+				IMAP_ACCESS_TOKEN: refreshed.accessToken,
+				MICROSOFT_REFRESH_TOKEN:
+					refreshed.refreshToken ?? parsedVaultValues.MICROSOFT_REFRESH_TOKEN,
+				SMTP_TOKEN_EXPIRES_AT: refreshed.expiresAt.toISOString(),
+				IMAP_TOKEN_EXPIRES_AT: refreshed.expiresAt.toISOString(),
+			};
+		}
 
-        const mailer = createMailer("smtp", parsedVaultValues);
-        const res = await mailer.verify(smtpAccountId);
+		const mailer = createMailer("smtp", parsedVaultValues);
+		const res = await mailer.verify(smtpAccountId);
 
-        parsedVaultValues.sendVerified = res?.meta?.send;
-        parsedVaultValues.receiveVerified = res?.meta?.receive;
+		parsedVaultValues.sendVerified = res?.meta?.send;
+		parsedVaultValues.receiveVerified = res?.meta?.receive;
 
-        await updateSecret(session, workspaceId, smtpSecret.metaId, {
-            value: JSON.stringify(parsedVaultValues),
-        });
+		await updateSecret(session, workspaceId, smtpSecret.metaId, {
+			value: JSON.stringify(parsedVaultValues),
+		});
 
-        return {
-            success: res.ok,
-            message: res.message,
-            data: res,
-        };
-    });
+		return {
+			success: res.ok,
+			message: res.message,
+			data: res,
+		};
+	});
 }
 
 export type CreateSMTPAccountInput = {
-    label?: string;
-    ulid: string;
-    required: Record<string, unknown>;
-    optional?: Record<string, unknown>;
+	label?: string;
+	ulid: string;
+	required: Record<string, unknown>;
+	optional?: Record<string, unknown>;
 };
 
 export async function createSMTPAccount(
-    input: CreateSMTPAccountInput,
+	input: CreateSMTPAccountInput,
 ): Promise<FormState<{ accountId: string }>> {
-    return handleAction(async () => {
-        const session = await currentSession();
-        const workspaceId = await getWorkspaceId();
-        const rls = await rlsClient();
+	return handleAction(async () => {
+		const session = await currentSession();
+		const workspaceId = await getWorkspaceId();
+		const rls = await rlsClient();
 
-        const smtpConfig: Record<string, unknown> = {
-            ulid: input.ulid,
-            label: String(input.label || "My SMTP Account").trim(),
-            ...input.required,
-            ...input.optional,
-        };
+		const smtpConfig: Record<string, unknown> = {
+			ulid: input.ulid,
+			label: String(input.label || "My SMTP Account").trim(),
+			...input.required,
+			...input.optional,
+		};
 
-        const secretMeta = await createSecret(session, workspaceId, {
-            name: input.ulid,
-            value: JSON.stringify(smtpConfig),
-        });
+		const secretMeta = await createSecret(session, workspaceId, {
+			name: input.ulid,
+			value: JSON.stringify(smtpConfig),
+		});
 
-        const [smtpAccount] = await rls((tx) =>
-            tx
-                .insert(smtpAccounts)
-                .values({})
-                .returning(),
-        );
+		const [smtpAccount] = await rls((tx) =>
+			tx.insert(smtpAccounts).values({}).returning(),
+		);
 
-        await rls((tx) =>
-            tx
-                .insert(smtpAccountSecrets)
-                .values({
-                    accountId: smtpAccount.id,
-                    secretId: secretMeta.id,
-                }),
-        );
+		await rls((tx) =>
+			tx.insert(smtpAccountSecrets).values({
+				accountId: smtpAccount.id,
+				secretId: secretMeta.id,
+			}),
+		);
 
-        const verification = await verifySMTPAccount(smtpAccount.id);
+		const verification = await verifySMTPAccount(smtpAccount.id);
 
-        if (!verification.success) {
-            await rls((tx) =>
-                tx
-                    .delete(smtpAccounts)
-                    .where(eq(smtpAccounts.id, smtpAccount.id)),
-            );
+		if (!verification.success) {
+			await rls((tx) =>
+				tx.delete(smtpAccounts).where(eq(smtpAccounts.id, smtpAccount.id)),
+			);
 
-            await deleteSecretAdmin(secretMeta.id);
+			await deleteSecretAdmin(secretMeta.id);
 
-            return {
-                success: false,
-                error:
-                    verification.error ||
-                    verification.message ||
-                    "SMTP verification failed",
-            };
-        }
+			return {
+				success: false,
+				error:
+					verification.error ||
+					verification.message ||
+					"SMTP verification failed",
+			};
+		}
 
-        return {
-            success: true,
-            message: verification.message || "dashboard.done",
-            data: {
-                accountId: smtpAccount.id,
-            },
-        };
-    });
+		return {
+			success: true,
+			message: verification.message || "dashboard.done",
+			data: {
+				accountId: smtpAccount.id,
+			},
+		};
+	});
 }
 
-
 export type UpdateSMTPAccountInput = {
-    accountId: string;
-    label?: string;
-    ulid: string;
-    required: Record<string, unknown>;
-    optional?: Record<string, unknown>;
+	accountId: string;
+	label?: string;
+	ulid: string;
+	required: Record<string, unknown>;
+	optional?: Record<string, unknown>;
 };
 
 export async function updateSMTPAccount(
-    input: UpdateSMTPAccountInput,
+	input: UpdateSMTPAccountInput,
 ): Promise<FormState<{ accountId: string }>> {
-    return handleAction(async () => {
-        const session = await currentSession();
-        const workspaceId = await getWorkspaceId();
-        const rls = await rlsClient();
+	return handleAction(async () => {
+		const session = await currentSession();
+		const workspaceId = await getWorkspaceId();
 
-        const [smtpSecret] = await fetchDecryptedSecrets({
-            linkTable: smtpAccountSecrets,
-            foreignCol: smtpAccountSecrets.accountId,
-            secretIdCol: smtpAccountSecrets.secretId,
-            parentId: input.accountId,
-        });
+		const [smtpSecret] = await fetchDecryptedSecrets({
+			linkTable: smtpAccountSecrets,
+			foreignCol: smtpAccountSecrets.accountId,
+			secretIdCol: smtpAccountSecrets.secretId,
+			parentId: input.accountId,
+		});
 
-        if (!smtpSecret) {
-            return {
-                success: false,
-                error: "SMTP account not found",
-            };
-        }
+		if (!smtpSecret) {
+			return {
+				success: false,
+				error: "SMTP account not found",
+			};
+		}
 
-        const previousConfig = { ...smtpSecret.parsedSecret };
+		const previousConfig = { ...smtpSecret.parsedSecret };
 
-        const smtpConfig: Record<string, unknown> = {
-            ulid: input.ulid,
-            label: String(input.label || "My SMTP Account").trim(),
-            ...input.required,
-            ...input.optional,
-        };
+		const smtpConfig: Record<string, unknown> = {
+			ulid: input.ulid,
+			label: String(input.label || "My SMTP Account").trim(),
+			...input.required,
+			...input.optional,
+		};
 
-        await updateSecret(session, workspaceId, smtpSecret.metaId, {
-            name: input.ulid,
-            value: JSON.stringify(smtpConfig),
-        });
+		await updateSecret(session, workspaceId, smtpSecret.metaId, {
+			name: input.ulid,
+			value: JSON.stringify(smtpConfig),
+		});
 
-        const verification = await verifySMTPAccount(input.accountId);
+		const verification = await verifySMTPAccount(input.accountId);
 
-        if (!verification.success) {
-            await updateSecret(session, workspaceId, smtpSecret.metaId, {
-                name: String(previousConfig.ulid),
-                value: JSON.stringify(previousConfig),
-            });
+		if (!verification.success) {
+			await updateSecret(session, workspaceId, smtpSecret.metaId, {
+				name: String(previousConfig.ulid),
+				value: JSON.stringify(previousConfig),
+			});
 
-            return {
-                success: false,
-                error:
-                    verification.error ||
-                    verification.message ||
-                    "SMTP verification failed",
-            };
-        }
+			return {
+				success: false,
+				error:
+					verification.error ||
+					verification.message ||
+					"SMTP verification failed",
+			};
+		}
 
-        return {
-            success: true,
-            message: verification.message || "dashboard.done",
-            data: {
-                accountId: input.accountId,
-            },
-        };
-    });
+		return {
+			success: true,
+			message: verification.message || "dashboard.done",
+			data: {
+				accountId: input.accountId,
+			},
+		};
+	});
 }

--- a/apps/web/lib/oauth/microsoft-compensation.test.ts
+++ b/apps/web/lib/oauth/microsoft-compensation.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { compensateMicrosoftOAuthResources } from "./microsoft-compensation";
+
+test("attempts every OAuth compensation independently and logs safe errors", async () => {
+	const attempted: string[] = [];
+	const logs: unknown[] = [];
+	await compensateMicrosoftOAuthResources(
+		"correlation-id",
+		["identity", "account", "link", "secret"].map((resource) => ({
+			resource,
+			cleanup: async () => {
+				attempted.push(resource);
+				if (resource === "account") throw new Error("database detail");
+			},
+		})),
+		(entry) => logs.push(entry),
+	);
+	assert.deepEqual(attempted, ["identity", "account", "link", "secret"]);
+	assert.deepEqual(logs, [
+		{
+			correlationId: "correlation-id",
+			resource: "account",
+			error: "database detail",
+		},
+	]);
+});

--- a/apps/web/lib/oauth/microsoft-compensation.ts
+++ b/apps/web/lib/oauth/microsoft-compensation.ts
@@ -1,0 +1,27 @@
+export type MicrosoftOAuthCleanup = {
+	resource: string;
+	cleanup: () => Promise<void>;
+};
+
+export async function compensateMicrosoftOAuthResources(
+	correlationId: string,
+	resources: MicrosoftOAuthCleanup[],
+	log: (entry: {
+		correlationId: string;
+		resource: string;
+		error: string;
+	}) => void = (entry) =>
+		console.error("[MICROSOFT OAUTH CLEANUP FAILED]", entry),
+) {
+	for (const { resource, cleanup } of resources) {
+		try {
+			await cleanup();
+		} catch (error) {
+			log({
+				correlationId,
+				resource,
+				error: error instanceof Error ? error.message : "unknown cleanup error",
+			});
+		}
+	}
+}

--- a/apps/web/lib/oauth/microsoft-oidc.ts
+++ b/apps/web/lib/oauth/microsoft-oidc.ts
@@ -1,0 +1,22 @@
+import { createRemoteJWKSet, jwtVerify } from "jose";
+
+const MICROSOFT_JWKS = createRemoteJWKSet(
+	new URL("https://login.microsoftonline.com/common/discovery/v2.0/keys"),
+);
+
+export async function verifyMicrosoftIdToken(input: {
+	token: string;
+	clientId: string;
+	nonce: string;
+}) {
+	const { payload } = await jwtVerify(input.token, MICROSOFT_JWKS, {
+		audience: input.clientId,
+		algorithms: ["RS256"],
+		requiredClaims: ["iss", "aud", "exp", "nonce", "tid"],
+	});
+	const tenantId = typeof payload.tid === "string" ? payload.tid : "";
+	const issuer = `https://login.microsoftonline.com/${tenantId}/v2.0`;
+	if (payload.iss !== issuer) throw new Error("invalid_issuer");
+	if (payload.nonce !== input.nonce) throw new Error("invalid_nonce");
+	return payload;
+}

--- a/apps/web/lib/oauth/microsoft-transaction.test.ts
+++ b/apps/web/lib/oauth/microsoft-transaction.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+	buildMicrosoftAuthorizationUrl,
+	createMicrosoftOAuthState,
+} from "../../../../packages/providers/src/mail/microsoft-oauth";
+import { createMicrosoftOAuthTransactionRecord } from "./microsoft-transaction";
+
+test("uses one OAuth state in authorization URL and transaction record", () => {
+	const oauth = createMicrosoftOAuthState();
+	const transaction = createMicrosoftOAuthTransactionRecord({
+		userId: "user-id",
+		workspaceId: "workspace-id",
+		publicId: "public-id",
+		state: oauth.state,
+		codeVerifier: oauth.codeVerifier,
+		nonce: oauth.nonce,
+	});
+	const authorizationUrl = new URL(
+		buildMicrosoftAuthorizationUrl({
+			clientId: "client-id",
+			redirectUri: "https://app.example/callback",
+			state: oauth.state,
+			codeChallenge: "challenge",
+			nonce: oauth.nonce,
+		}),
+	);
+
+	assert.equal(authorizationUrl.searchParams.get("state"), transaction.state);
+});

--- a/apps/web/lib/oauth/microsoft-transaction.ts
+++ b/apps/web/lib/oauth/microsoft-transaction.ts
@@ -1,0 +1,42 @@
+import crypto from "node:crypto";
+import { getServerEnv } from "@schema";
+import Redis from "ioredis";
+
+export type MicrosoftOAuthTransaction = {
+	userId: string;
+	workspaceId: string;
+	publicId: string;
+	state: string;
+	codeVerifier: string;
+	nonce: string;
+};
+
+let redis: Redis | undefined;
+function getClient() {
+	if (!redis) {
+		const { REDIS_HOST, REDIS_PORT, REDIS_PASSWORD } = getServerEnv();
+		redis = new Redis({
+			host: REDIS_HOST || "redis",
+			port: Number(REDIS_PORT || 6379),
+			password: REDIS_PASSWORD,
+		});
+	}
+	return redis;
+}
+export async function createMicrosoftOAuthTransaction(
+	input: Omit<MicrosoftOAuthTransaction, "state">,
+) {
+	const id = crypto.randomBytes(32).toString("base64url");
+	const state = crypto.randomBytes(32).toString("base64url");
+	await getClient().set(
+		`oauth:microsoft:${id}`,
+		JSON.stringify({ ...input, state }),
+		"EX",
+		600,
+	);
+	return { id, state };
+}
+export async function consumeMicrosoftOAuthTransaction(id: string) {
+	const raw = await getClient().getdel(`oauth:microsoft:${id}`);
+	return raw ? (JSON.parse(raw) as MicrosoftOAuthTransaction) : null;
+}

--- a/apps/web/lib/oauth/microsoft-transaction.ts
+++ b/apps/web/lib/oauth/microsoft-transaction.ts
@@ -23,18 +23,23 @@ function getClient() {
 	}
 	return redis;
 }
+export function createMicrosoftOAuthTransactionRecord(
+	input: MicrosoftOAuthTransaction,
+) {
+	return input;
+}
+
 export async function createMicrosoftOAuthTransaction(
-	input: Omit<MicrosoftOAuthTransaction, "state">,
+	input: MicrosoftOAuthTransaction,
 ) {
 	const id = crypto.randomBytes(32).toString("base64url");
-	const state = crypto.randomBytes(32).toString("base64url");
 	await getClient().set(
 		`oauth:microsoft:${id}`,
-		JSON.stringify({ ...input, state }),
+		JSON.stringify(createMicrosoftOAuthTransactionRecord(input)),
 		"EX",
 		600,
 	);
-	return { id, state };
+	return { id, state: input.state };
 }
 export async function consumeMicrosoftOAuthTransaction(id: string) {
 	const raw = await getClient().getdel(`oauth:microsoft:${id}`);

--- a/apps/worker/lib/imap/imap-client.ts
+++ b/apps/worker/lib/imap/imap-client.ts
@@ -1,4 +1,15 @@
-import { db, decryptAdminSecrets, identities, smtpAccountSecrets } from "@db";
+import {
+	db,
+	decryptAdminSecrets,
+	identities,
+	smtpAccountSecrets,
+	updateSecretAdmin,
+} from "@db";
+import {
+	isMicrosoftTokenExpired,
+	refreshMicrosoftAccessToken,
+	withMicrosoftRefreshLock,
+} from "@providers";
 import { eq } from "drizzle-orm";
 import { ImapFlow } from "imapflow";
 
@@ -41,9 +52,74 @@ export const initSmtpClient = async (
 			parentId: String(identity.smtpAccountId),
 		});
 
-		const credentials = secrets?.vault?.decrypted_secret
+		let credentials = secrets?.vault?.decrypted_secret
 			? JSON.parse(secrets.vault.decrypted_secret)
 			: {};
+
+		if (
+			credentials.provider === "microsoft" &&
+			credentials.MICROSOFT_REFRESH_TOKEN &&
+			credentials.IMAP_TOKEN_EXPIRES_AT &&
+			isMicrosoftTokenExpired(new Date(credentials.IMAP_TOKEN_EXPIRES_AT))
+		) {
+			const refreshed = await withMicrosoftRefreshLock(
+				String(secrets.metaId),
+				() =>
+					refreshMicrosoftAccessToken({
+						clientId: String(credentials.MICROSOFT_CLIENT_ID),
+						refreshToken: String(credentials.MICROSOFT_REFRESH_TOKEN),
+						tenant: String(credentials.MICROSOFT_TENANT),
+					}),
+				async (next) => {
+					credentials = {
+						...credentials,
+						SMTP_ACCESS_TOKEN: next.accessToken,
+						IMAP_ACCESS_TOKEN: next.accessToken,
+						MICROSOFT_REFRESH_TOKEN:
+							next.refreshToken ?? credentials.MICROSOFT_REFRESH_TOKEN,
+						SMTP_TOKEN_EXPIRES_AT: next.expiresAt.toISOString(),
+						IMAP_TOKEN_EXPIRES_AT: next.expiresAt.toISOString(),
+					};
+					await updateSecretAdmin(String(secrets.metaId), {
+						value: JSON.stringify(credentials),
+					});
+				},
+				async () => {
+					const [latest] = await decryptAdminSecrets({
+						linkTable: smtpAccountSecrets,
+						foreignCol: smtpAccountSecrets.accountId,
+						secretIdCol: smtpAccountSecrets.secretId,
+						ownerId: identity.ownerId,
+						parentId: String(identity.smtpAccountId),
+					});
+					const values = latest?.vault?.decrypted_secret
+						? JSON.parse(latest.vault.decrypted_secret)
+						: null;
+					if (
+						!values?.IMAP_ACCESS_TOKEN ||
+						!values.IMAP_TOKEN_EXPIRES_AT ||
+						isMicrosoftTokenExpired(new Date(values.IMAP_TOKEN_EXPIRES_AT))
+					)
+						return null;
+					return {
+						accessToken: String(values.IMAP_ACCESS_TOKEN),
+						refreshToken: String(values.MICROSOFT_REFRESH_TOKEN),
+						expiresAt: new Date(values.IMAP_TOKEN_EXPIRES_AT),
+						tokenType: "Bearer",
+					};
+				},
+				{ distributed: true },
+			);
+			credentials = {
+				...credentials,
+				SMTP_ACCESS_TOKEN: refreshed.accessToken,
+				IMAP_ACCESS_TOKEN: refreshed.accessToken,
+				MICROSOFT_REFRESH_TOKEN:
+					refreshed.refreshToken ?? credentials.MICROSOFT_REFRESH_TOKEN,
+				SMTP_TOKEN_EXPIRES_AT: refreshed.expiresAt.toISOString(),
+				IMAP_TOKEN_EXPIRES_AT: refreshed.expiresAt.toISOString(),
+			};
+		}
 
 		const client = new ImapFlow({
 			host: credentials.IMAP_HOST,
@@ -71,11 +147,17 @@ export const initSmtpClient = async (
 			socketTimeout: 60_000,
 
 			logger: {
-				error(data: any) {
-					console.error(`[IMAP:${identityId}]`, data?.msg ?? data);
+				error(data: unknown) {
+					console.error(
+						`[IMAP:${identityId}]`,
+						(data as { msg?: unknown })?.msg ?? data,
+					);
 				},
-				warn(data: any) {
-					console.warn(`[IMAP:${identityId}]`, data?.msg ?? data);
+				warn(data: unknown) {
+					console.warn(
+						`[IMAP:${identityId}]`,
+						(data as { msg?: unknown })?.msg ?? data,
+					);
 				},
 				info() {},
 				debug() {},

--- a/apps/worker/lib/imap/imap-client.ts
+++ b/apps/worker/lib/imap/imap-client.ts
@@ -18,10 +18,7 @@ export const initSmtpClient = async (
 			existing.removeAllListeners();
 			existing.close();
 		} catch (err) {
-			console.warn(
-				`[IMAP:${identityId}] Failed to close stale client`,
-				err,
-			);
+			console.warn(`[IMAP:${identityId}] Failed to close stale client`, err);
 		}
 	}
 
@@ -52,13 +49,18 @@ export const initSmtpClient = async (
 			host: credentials.IMAP_HOST,
 			port: Number(credentials.IMAP_PORT),
 			secure:
-				credentials.IMAP_SECURE === "true" ||
-				credentials.IMAP_SECURE === true,
+				credentials.IMAP_SECURE === "true" || credentials.IMAP_SECURE === true,
 
-			auth: {
-				user: credentials.IMAP_USERNAME,
-				pass: credentials.IMAP_PASSWORD,
-			},
+			auth:
+				credentials.IMAP_AUTH_METHOD === "xoauth2"
+					? {
+							user: credentials.IMAP_USERNAME,
+							accessToken: credentials.IMAP_ACCESS_TOKEN,
+						}
+					: {
+							user: credentials.IMAP_USERNAME,
+							pass: credentials.IMAP_PASSWORD,
+						},
 
 			/*
 			 * Keep this unchanged for now.
@@ -70,16 +72,10 @@ export const initSmtpClient = async (
 
 			logger: {
 				error(data: any) {
-					console.error(
-						`[IMAP:${identityId}]`,
-						data?.msg ?? data,
-					);
+					console.error(`[IMAP:${identityId}]`, data?.msg ?? data);
 				},
 				warn(data: any) {
-					console.warn(
-						`[IMAP:${identityId}]`,
-						data?.msg ?? data,
-					);
+					console.warn(`[IMAP:${identityId}]`, data?.msg ?? data);
 				},
 				info() {},
 				debug() {},
@@ -115,10 +111,7 @@ export const initSmtpClient = async (
 		try {
 			await client.connect();
 		} catch (err) {
-			console.error(
-				`[IMAP:${identityId}] connect() failed:`,
-				err,
-			);
+			console.error(`[IMAP:${identityId}] connect() failed:`, err);
 
 			if (imapInstances.get(identityId) === client) {
 				imapInstances.delete(identityId);

--- a/apps/worker/lib/imap/imap-client.ts
+++ b/apps/worker/lib/imap/imap-client.ts
@@ -6,9 +6,7 @@ import {
 	updateSecretAdmin,
 } from "@db";
 import {
-	isMicrosoftTokenExpired,
-	refreshMicrosoftAccessToken,
-	withMicrosoftRefreshLock,
+	loadMicrosoftCredentials,
 } from "@providers";
 import { eq } from "drizzle-orm";
 import { ImapFlow } from "imapflow";
@@ -56,70 +54,26 @@ export const initSmtpClient = async (
 			? JSON.parse(secrets.vault.decrypted_secret)
 			: {};
 
-		if (
-			credentials.provider === "microsoft" &&
-			credentials.MICROSOFT_REFRESH_TOKEN &&
-			credentials.IMAP_TOKEN_EXPIRES_AT &&
-			isMicrosoftTokenExpired(new Date(credentials.IMAP_TOKEN_EXPIRES_AT))
-		) {
-			const refreshed = await withMicrosoftRefreshLock(
-				String(secrets.metaId),
-				() =>
-					refreshMicrosoftAccessToken({
-						clientId: String(credentials.MICROSOFT_CLIENT_ID),
-						refreshToken: String(credentials.MICROSOFT_REFRESH_TOKEN),
-						tenant: String(credentials.MICROSOFT_TENANT),
-					}),
-				async (next) => {
-					credentials = {
-						...credentials,
-						SMTP_ACCESS_TOKEN: next.accessToken,
-						IMAP_ACCESS_TOKEN: next.accessToken,
-						MICROSOFT_REFRESH_TOKEN:
-							next.refreshToken ?? credentials.MICROSOFT_REFRESH_TOKEN,
-						SMTP_TOKEN_EXPIRES_AT: next.expiresAt.toISOString(),
-						IMAP_TOKEN_EXPIRES_AT: next.expiresAt.toISOString(),
-					};
-					await updateSecretAdmin(String(secrets.metaId), {
-						value: JSON.stringify(credentials),
-					});
-				},
-				async () => {
-					const [latest] = await decryptAdminSecrets({
-						linkTable: smtpAccountSecrets,
-						foreignCol: smtpAccountSecrets.accountId,
-						secretIdCol: smtpAccountSecrets.secretId,
-						ownerId: identity.ownerId,
-						parentId: String(identity.smtpAccountId),
-					});
-					const values = latest?.vault?.decrypted_secret
-						? JSON.parse(latest.vault.decrypted_secret)
-						: null;
-					if (
-						!values?.IMAP_ACCESS_TOKEN ||
-						!values.IMAP_TOKEN_EXPIRES_AT ||
-						isMicrosoftTokenExpired(new Date(values.IMAP_TOKEN_EXPIRES_AT))
-					)
-						return null;
-					return {
-						accessToken: String(values.IMAP_ACCESS_TOKEN),
-						refreshToken: String(values.MICROSOFT_REFRESH_TOKEN),
-						expiresAt: new Date(values.IMAP_TOKEN_EXPIRES_AT),
-						tokenType: "Bearer",
-					};
-				},
-				{ distributed: true },
-			);
-			credentials = {
-				...credentials,
-				SMTP_ACCESS_TOKEN: refreshed.accessToken,
-				IMAP_ACCESS_TOKEN: refreshed.accessToken,
-				MICROSOFT_REFRESH_TOKEN:
-					refreshed.refreshToken ?? credentials.MICROSOFT_REFRESH_TOKEN,
-				SMTP_TOKEN_EXPIRES_AT: refreshed.expiresAt.toISOString(),
-				IMAP_TOKEN_EXPIRES_AT: refreshed.expiresAt.toISOString(),
-			};
-		}
+		credentials = await loadMicrosoftCredentials(credentials, {
+			key: String(secrets.metaId),
+			distributed: true,
+			persist: async (next) => {
+				await updateSecretAdmin(String(secrets.metaId), {
+					value: JSON.stringify(next),
+					expectedEncryptedValue: secrets.encryptedValue,
+				});
+			},
+			load: async () => {
+				const [latest] = await decryptAdminSecrets({
+					linkTable: smtpAccountSecrets,
+					foreignCol: smtpAccountSecrets.accountId,
+					secretIdCol: smtpAccountSecrets.secretId,
+					ownerId: identity.ownerId,
+					parentId: String(identity.smtpAccountId),
+				});
+				return latest?.vault?.decrypted_secret ? JSON.parse(latest.vault.decrypted_secret) : null;
+			},
+		});
 
 		const client = new ImapFlow({
 			host: credentials.IMAP_HOST,

--- a/apps/worker/server/plugins/send-mail.ts
+++ b/apps/worker/server/plugins/send-mail.ts
@@ -28,7 +28,7 @@ import {
 	getSecretAdmin,
 	jmapAccounts,
 } from "@db";
-import { createMailer } from "@providers";
+import { createMailer, loadMicrosoftCredentials } from "@providers";
 import { toArray } from "drizzle-orm/mysql-core";
 import { and, eq } from "drizzle-orm";
 import addressparser from "addressparser";
@@ -274,6 +274,27 @@ export default defineNitroPlugin(async (nitroApp) => {
 							secrets.vault.decrypted_secret,
 						)
 						: {};
+
+				if (providerType === "smtp") {
+					credentials = await loadMicrosoftCredentials(credentials, {
+						key: String(secrets.metaId),
+						distributed: true,
+						persist: async (next) => updateSecretAdmin(String(secrets.metaId), {
+							value: JSON.stringify(next),
+							expectedEncryptedValue: secrets.encryptedValue,
+						}),
+						load: async () => {
+							const [latest] = await decryptAdminSecrets({
+								linkTable: smtpAccountSecrets,
+								foreignCol: smtpAccountSecrets.accountId,
+								secretIdCol: smtpAccountSecrets.secretId,
+								ownerId: mailbox.identity.ownerId,
+								parentId: String(mailbox.identity.smtpAccountId),
+							});
+							return latest?.vault?.decrypted_secret ? JSON.parse(latest.vault.decrypted_secret) : null;
+						},
+					});
+				}
 			}
 
 			const mailer = createMailer(

--- a/packages/db/src/drizzle/helpers.ts
+++ b/packages/db/src/drizzle/helpers.ts
@@ -49,6 +49,7 @@ export async function decryptAdminSecrets({
 			return {
 				linkRow: r.linkRow,
 				metaId,
+				encryptedValue: r.encryptedValue,
 				vault,
 				providerId: (r as any)?.linkRow?.providerId,
 				accountId: (r as any)?.linkRow?.accountId,

--- a/packages/db/src/drizzle/helpers.ts
+++ b/packages/db/src/drizzle/helpers.ts
@@ -24,6 +24,7 @@ export async function decryptAdminSecrets({
 		.select({
 			linkRow: linkTable,
 			metaId: secretsMeta.id,
+			encryptedValue: secretsMeta.encryptedValue,
 			provider: providers,
 			smtpAccount: smtpAccounts,
 		})

--- a/packages/db/src/drizzle/vault.ts
+++ b/packages/db/src/drizzle/vault.ts
@@ -170,7 +170,7 @@ export async function updateSecret(
 	session: string,
 	workspaceId: string,
 	id: string,
-	input: { value?: string; name?: string, description?: string | null; },
+	input: { value?: string; name?: string, description?: string | null; expectedEncryptedValue?: string },
 ) {
 	const db = await createDrizzleClientInstance(session, { workspaceId });
 	const { rls } = db;
@@ -194,9 +194,10 @@ export async function updateSecret(
 	if (Object.keys(patch).length === 0) return meta;
 
 	const rows = await rls((tx) =>
-		tx.update(secretsMeta).set(patch).where(eq(secretsMeta.id, id)).returning(),
+		tx.update(secretsMeta).set(patch).where(and(eq(secretsMeta.id, id), ...(input.expectedEncryptedValue ? [eq(secretsMeta.encryptedValue, input.expectedEncryptedValue)] : []))).returning(),
 	);
 
+	if (!rows[0]) throw new Error("Secret changed during Microsoft refresh");
 	return rows[0]!;
 }
 
@@ -218,7 +219,7 @@ export async function deleteSecret(
 
 export async function updateSecretAdmin(
 	id: string,
-	input: { value?: string; name?: string },
+	input: { value?: string; name?: string; expectedEncryptedValue?: string },
 ) {
 	const db = createDb();
 	const meta = await db
@@ -247,9 +248,10 @@ export async function updateSecretAdmin(
 	const rows = await db
 		.update(secretsMeta)
 		.set(patch)
-		.where(eq(secretsMeta.id, id))
+		.where(and(eq(secretsMeta.id, id), ...(input.expectedEncryptedValue ? [eq(secretsMeta.encryptedValue, input.expectedEncryptedValue)] : [])))
 		.returning();
 
+	if (!rows[0]) throw new Error("Secret changed during Microsoft refresh");
 	return rows[0]!;
 }
 

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -23,6 +23,7 @@
 		"@sendgrid/mail": "^8.1.6",
 		"googleapis": "^173.0.0",
 		"imapflow": "^1.0.198",
+		"ioredis": "^5.8.1",
 		"mailgun.js": "^12.1.0",
 		"nodemailer": "^7.0.6",
 		"postmark": "^4.0.5"

--- a/packages/providers/src/core.ts
+++ b/packages/providers/src/core.ts
@@ -68,15 +68,17 @@ export const RawSmtpConfigSchema = z
 				? {
 						type: "OAuth2" as const,
 						user: r.SMTP_USERNAME,
-						accessToken: r.SMTP_ACCESS_TOKEN!,
+						accessToken: r.SMTP_ACCESS_TOKEN ?? "",
 					}
-				: { user: r.SMTP_USERNAME, pass: r.SMTP_PASSWORD! },
+				: { user: r.SMTP_USERNAME, pass: r.SMTP_PASSWORD ?? "" },
 		pool: r.SMTP_POOL,
 		provider: r.MICROSOFT_REFRESH_TOKEN ? "microsoft" : undefined,
 		refreshToken: r.MICROSOFT_REFRESH_TOKEN,
 		tenant: r.MICROSOFT_TENANT,
 		clientId: r.MICROSOFT_CLIENT_ID,
-		expiresAt: r.SMTP_TOKEN_EXPIRES_AT ? new Date(r.SMTP_TOKEN_EXPIRES_AT) : undefined,
+		expiresAt: r.SMTP_TOKEN_EXPIRES_AT
+			? new Date(r.SMTP_TOKEN_EXPIRES_AT)
+			: undefined,
 		imap:
 			r.IMAP_HOST &&
 			r.IMAP_PORT &&

--- a/packages/providers/src/core.ts
+++ b/packages/providers/src/core.ts
@@ -1,5 +1,5 @@
+import type { IdentityStatus } from "@schema";
 import { z } from "zod";
-import { IdentityStatus } from "@schema";
 
 export type VerifyResult = {
 	ok: boolean;

--- a/packages/providers/src/core.ts
+++ b/packages/providers/src/core.ts
@@ -6,7 +6,7 @@ export type VerifyResult = {
 	message?: string;
 	meta?: Record<string, unknown>;
 };
-
+const AuthMethod = z.enum(["password", "xoauth2"]);
 export const RawSmtpConfigSchema = z
 	.object({
 		SMTP_HOST: z.string(),
@@ -15,14 +15,15 @@ export const RawSmtpConfigSchema = z
 			.enum(["true", "false"])
 			.transform((v) => v === "true")
 			.optional(),
-
 		SMTP_USERNAME: z.string(),
-		SMTP_PASSWORD: z.string(),
+		SMTP_PASSWORD: z.string().optional(),
 		SMTP_POOL: z
 			.enum(["true", "false"])
 			.transform((v) => v === "true")
 			.optional(),
-
+		SMTP_AUTH_METHOD: AuthMethod.optional(),
+		SMTP_ACCESS_TOKEN: z.string().optional(),
+		SMTP_TOKEN_EXPIRES_AT: z.string().datetime().optional(),
 		IMAP_HOST: z.string().optional(),
 		IMAP_PORT: z.coerce.number().optional(),
 		IMAP_USERNAME: z.string().optional(),
@@ -31,28 +32,60 @@ export const RawSmtpConfigSchema = z
 			.enum(["true", "false"])
 			.transform((v) => v === "true")
 			.optional(),
+		IMAP_AUTH_METHOD: AuthMethod.optional(),
+		IMAP_ACCESS_TOKEN: z.string().optional(),
+		IMAP_TOKEN_EXPIRES_AT: z.string().datetime().optional(),
+	})
+	.superRefine((r, ctx) => {
+		if ((r.SMTP_AUTH_METHOD ?? "password") === "password" && !r.SMTP_PASSWORD)
+			ctx.addIssue({
+				code: "custom",
+				path: ["SMTP_PASSWORD"],
+				message: "SMTP_PASSWORD is required for password authentication",
+			});
+		if (r.SMTP_AUTH_METHOD === "xoauth2" && !r.SMTP_ACCESS_TOKEN)
+			ctx.addIssue({
+				code: "custom",
+				path: ["SMTP_ACCESS_TOKEN"],
+				message: "SMTP_ACCESS_TOKEN is required for XOAUTH2 authentication",
+			});
+		if (r.IMAP_AUTH_METHOD === "xoauth2" && !r.IMAP_ACCESS_TOKEN)
+			ctx.addIssue({
+				code: "custom",
+				path: ["IMAP_ACCESS_TOKEN"],
+				message: "IMAP_ACCESS_TOKEN is required for XOAUTH2 authentication",
+			});
 	})
 	.transform((r) => ({
 		host: r.SMTP_HOST,
 		port: r.SMTP_PORT,
 		secure: r.SMTP_SECURE ?? false,
-		auth: { user: r.SMTP_USERNAME, pass: r.SMTP_PASSWORD },
+		auth:
+			r.SMTP_AUTH_METHOD === "xoauth2"
+				? {
+						type: "OAuth2" as const,
+						user: r.SMTP_USERNAME,
+						accessToken: r.SMTP_ACCESS_TOKEN!,
+					}
+				: { user: r.SMTP_USERNAME, pass: r.SMTP_PASSWORD! },
 		pool: r.SMTP_POOL,
-
 		imap:
-			r.IMAP_HOST && r.IMAP_PORT && r.IMAP_USERNAME && r.IMAP_PASSWORD
+			r.IMAP_HOST &&
+			r.IMAP_PORT &&
+			r.IMAP_USERNAME &&
+			(r.IMAP_AUTH_METHOD === "xoauth2" ? r.IMAP_ACCESS_TOKEN : r.IMAP_PASSWORD)
 				? {
 						host: r.IMAP_HOST,
 						port: r.IMAP_PORT,
 						user: r.IMAP_USERNAME,
 						pass: r.IMAP_PASSWORD,
+						accessToken: r.IMAP_ACCESS_TOKEN,
 						secure: r.IMAP_SECURE ?? true,
+						authMethod: r.IMAP_AUTH_METHOD ?? "password",
 					}
 				: undefined,
 	}));
-
 export type SmtpVerifyInput = z.infer<typeof RawSmtpConfigSchema>;
-
 export const RawSesConfigSchema = z
 	.object({
 		SES_ACCESS_KEY_ID: z.string(),

--- a/packages/providers/src/core.ts
+++ b/packages/providers/src/core.ts
@@ -24,6 +24,9 @@ export const RawSmtpConfigSchema = z
 		SMTP_AUTH_METHOD: AuthMethod.optional(),
 		SMTP_ACCESS_TOKEN: z.string().optional(),
 		SMTP_TOKEN_EXPIRES_AT: z.string().datetime().optional(),
+		MICROSOFT_REFRESH_TOKEN: z.string().optional(),
+		MICROSOFT_TENANT: z.string().optional(),
+		MICROSOFT_CLIENT_ID: z.string().optional(),
 		IMAP_HOST: z.string().optional(),
 		IMAP_PORT: z.coerce.number().optional(),
 		IMAP_USERNAME: z.string().optional(),
@@ -69,6 +72,11 @@ export const RawSmtpConfigSchema = z
 					}
 				: { user: r.SMTP_USERNAME, pass: r.SMTP_PASSWORD! },
 		pool: r.SMTP_POOL,
+		provider: r.MICROSOFT_REFRESH_TOKEN ? "microsoft" : undefined,
+		refreshToken: r.MICROSOFT_REFRESH_TOKEN,
+		tenant: r.MICROSOFT_TENANT,
+		clientId: r.MICROSOFT_CLIENT_ID,
+		expiresAt: r.SMTP_TOKEN_EXPIRES_AT ? new Date(r.SMTP_TOKEN_EXPIRES_AT) : undefined,
 		imap:
 			r.IMAP_HOST &&
 			r.IMAP_PORT &&

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -8,7 +8,7 @@ import { PostmarkMailer } from "./mail/postmark";
 import { GoogleMailer } from "./mail/google";
 
 import { S3Store } from "./store/s3";
-import {JmapMailer} from "./mail/jmap";
+import { JmapMailer } from "./mail/jmap";
 
 export function createMailer(provider: Providers, config: unknown): Mailer {
 	switch (provider) {
@@ -45,3 +45,5 @@ export function createStore(
 
 export * from "./core";
 export * from "./mail/google-client";
+
+export * from "./mail/microsoft-oauth";

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -1,14 +1,13 @@
 import type { Providers } from "@schema";
-import { Mailer, StorageProvider } from "./core";
-import { SmtpMailer } from "./mail/smtp";
-import { SesMailer } from "./mail/ses";
-import { SendgridMailer } from "./mail/sendgrid";
+import type { Mailer, StorageProvider } from "./core";
+import { GoogleMailer } from "./mail/google";
+import { JmapMailer } from "./mail/jmap";
 import { MailgunMailer } from "./mail/mailgun";
 import { PostmarkMailer } from "./mail/postmark";
-import { GoogleMailer } from "./mail/google";
-
+import { SendgridMailer } from "./mail/sendgrid";
+import { SesMailer } from "./mail/ses";
+import { SmtpMailer } from "./mail/smtp";
 import { S3Store } from "./store/s3";
-import { JmapMailer } from "./mail/jmap";
 
 export function createMailer(provider: Providers, config: unknown): Mailer {
 	switch (provider) {

--- a/packages/providers/src/mail/microsoft-oauth.test.ts
+++ b/packages/providers/src/mail/microsoft-oauth.test.ts
@@ -105,8 +105,11 @@ test("reports actionable Microsoft refresh errors", async () => {
 });
 test("formats the RFC 7628 XOAUTH2 initial client response", () => {
 	assert.equal(
-		xoauth2String("person@example.com", "access-token"),
-		"dXNlcj1wZXJzb25AZXhhbXBsZS5jb20BYXV0aD1CZWFyZXIgYWNjZXNzLXRva2VuAQE=",
+		Buffer.from(
+			xoauth2String("person@example.com", "access-token"),
+			"base64",
+		).toString("utf8"),
+		"user=person@example.com\x01auth=Bearer access-token\x01\x01",
 	);
 });
 
@@ -165,4 +168,29 @@ test("coalesces concurrent refreshes and persists the rotated token once", async
 	assert.deepEqual(result, ["token-1", "token-1"]);
 	assert.equal(refreshes, 1);
 	assert.equal(saves, 1);
+});
+
+test("renews a distributed refresh lease until persistence completes", async () => {
+	const calls: string[] = [];
+	const redis = {
+		set: async () => "OK",
+		eval: async (...args: unknown[]) => {
+			const script = String(args[0]);
+			if (script.includes("pexpire")) calls.push("renew");
+			else calls.push("release");
+			return 1;
+		},
+	};
+	await withMicrosoftRefreshLock(
+		"lease-test",
+		async () => {
+			await new Promise((resolve) => setTimeout(resolve, 30));
+			return "rotated-token";
+		},
+		async () => {},
+		undefined,
+		{ distributed: true, redis, leaseMs: 15, renewEveryMs: 5 },
+	);
+	assert.ok(calls.includes("renew"));
+	assert.equal(calls.at(-1), "release");
 });

--- a/packages/providers/src/mail/microsoft-oauth.test.ts
+++ b/packages/providers/src/mail/microsoft-oauth.test.ts
@@ -139,6 +139,38 @@ test("does not expose provider error descriptions", async () => {
 	);
 });
 
+test("centralizes expired Microsoft SMTP and IMAP credential refresh", async () => {
+	const { loadMicrosoftCredentials } = await import("./microsoft-oauth");
+	let saved: Record<string, unknown> | undefined;
+	const credentials = {
+		provider: "microsoft",
+		MICROSOFT_CLIENT_ID: "client",
+		MICROSOFT_REFRESH_TOKEN: "old-refresh",
+		MICROSOFT_TENANT: "common",
+		SMTP_TOKEN_EXPIRES_AT: new Date(Date.now() - 1_000).toISOString(),
+		IMAP_TOKEN_EXPIRES_AT: new Date(Date.now() - 1_000).toISOString(),
+	};
+	const result = await loadMicrosoftCredentials(credentials, {
+		key: "loader-test",
+		persist: async (next) => {
+			saved = next;
+		},
+		fetcher: async () =>
+			new Response(
+				JSON.stringify({
+					access_token: "new-access",
+					refresh_token: "new-refresh",
+					expires_in: 3600,
+				}),
+				{ status: 200 },
+			),
+	});
+	assert.equal(result.SMTP_ACCESS_TOKEN, "new-access");
+	assert.equal(result.IMAP_ACCESS_TOKEN, "new-access");
+	assert.equal(result.MICROSOFT_REFRESH_TOKEN, "new-refresh");
+	assert.equal(saved?.MICROSOFT_REFRESH_TOKEN, "new-refresh");
+});
+
 test("coalesces concurrent refreshes and persists the rotated token once", async () => {
 	let refreshes = 0;
 	let saves = 0;
@@ -193,4 +225,32 @@ test("renews a distributed refresh lease until persistence completes", async () 
 	);
 	assert.ok(calls.includes("renew"));
 	assert.equal(calls.at(-1), "release");
+});
+
+test("does not persist with a stale refresh fence", async () => {
+	let persisted = false;
+	const redis = {
+		set: async () => "OK",
+		eval: async (...args: unknown[]) => {
+			const script = String(args[0]);
+			if (script.includes("pexpire")) return 0;
+			return 1;
+		},
+	};
+	await assert.rejects(
+		withMicrosoftRefreshLock(
+			"stale-fence",
+			async () => {
+				await new Promise((resolve) => setTimeout(resolve, 5));
+				return "rotated-token";
+			},
+			async () => {
+				persisted = true;
+			},
+			undefined,
+			{ distributed: true, redis, leaseMs: 20, renewEveryMs: 1 },
+		),
+		/Microsoft refresh lock lease lost/,
+	);
+	assert.equal(persisted, false);
 });

--- a/packages/providers/src/mail/microsoft-oauth.test.ts
+++ b/packages/providers/src/mail/microsoft-oauth.test.ts
@@ -2,15 +2,50 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
 	buildMicrosoftAuthorizationUrl,
+	createMicrosoftCredentials,
 	createMicrosoftOAuthState,
 	exchangeMicrosoftAuthorizationCode,
 	isMicrosoftTokenExpired,
+	loadMicrosoftCredentials,
 	MICROSOFT_MAIL_SCOPES,
 	refreshMicrosoftAccessToken,
 	validateMicrosoftOAuthState,
 	withMicrosoftRefreshLock,
 	xoauth2String,
 } from "./microsoft-oauth";
+
+test("OAuth-created Microsoft credentials reach the refresh loader", async () => {
+	const credentials = createMicrosoftCredentials({
+		email: "person@example.com",
+		clientId: "client",
+		tenant: "common",
+		token: {
+			accessToken: "expired-access",
+			refreshToken: "old-refresh",
+			expiresAt: new Date(Date.now() - 1_000),
+			tokenType: "Bearer",
+		},
+	});
+	let persisted: Record<string, unknown> | undefined;
+	const result = await loadMicrosoftCredentials(credentials, {
+		key: "oauth-created-account",
+		persist: async (next) => {
+			persisted = next;
+		},
+		fetcher: async () =>
+			new Response(
+				JSON.stringify({
+					access_token: "fresh-access",
+					refresh_token: "fresh-refresh",
+					expires_in: 3600,
+				}),
+				{ status: 200 },
+			),
+	});
+	assert.equal(result.provider, "microsoft");
+	assert.equal(result.IMAP_ACCESS_TOKEN, "fresh-access");
+	assert.equal(persisted?.MICROSOFT_REFRESH_TOKEN, "fresh-refresh");
+});
 
 test("builds Microsoft authorization URL with PKCE and state", () => {
 	const url = new URL(
@@ -200,6 +235,29 @@ test("coalesces concurrent refreshes and persists the rotated token once", async
 	assert.deepEqual(result, ["token-1", "token-1"]);
 	assert.equal(refreshes, 1);
 	assert.equal(saves, 1);
+});
+
+test("passes the distributed fence to CAS persistence", async () => {
+	let owner = "";
+	let persisted = false;
+	const redis = {
+		set: async (...args: string[]) => {
+			owner = args[1];
+			return "OK";
+		},
+		eval: async () => 1,
+	};
+	await withMicrosoftRefreshLock(
+		"cas-test",
+		async () => "rotated-token",
+		async (_value, fenceToken) => {
+			if (fenceToken !== owner) throw new Error("stale CAS fence rejected");
+			persisted = true;
+		},
+		undefined,
+		{ distributed: true, redis },
+	);
+	assert.equal(persisted, true);
 });
 
 test("renews a distributed refresh lease until persistence completes", async () => {

--- a/packages/providers/src/mail/microsoft-oauth.test.ts
+++ b/packages/providers/src/mail/microsoft-oauth.test.ts
@@ -1,0 +1,103 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+	MICROSOFT_MAIL_SCOPES,
+	buildMicrosoftAuthorizationUrl,
+	createMicrosoftOAuthState,
+	exchangeMicrosoftAuthorizationCode,
+	refreshMicrosoftAccessToken,
+	xoauth2String,
+	isMicrosoftTokenExpired,
+	validateMicrosoftOAuthState,
+} from "./microsoft-oauth";
+
+test("builds Microsoft authorization URL with PKCE and state", () => {
+	const url = new URL(
+		buildMicrosoftAuthorizationUrl({
+			clientId: "client-id",
+			redirectUri: "https://app.example/callback",
+			state: "state-value",
+			codeChallenge: "challenge-value",
+			tenant: "organizations",
+		}),
+	);
+	assert.equal(url.origin, "https://login.microsoftonline.com");
+	assert.equal(url.pathname, "/organizations/oauth2/v2.0/authorize");
+	assert.equal(url.searchParams.get("response_type"), "code");
+	assert.equal(url.searchParams.get("code_challenge"), "challenge-value");
+	assert.equal(url.searchParams.get("code_challenge_method"), "S256");
+	assert.equal(url.searchParams.get("state"), "state-value");
+	assert.equal(url.searchParams.get("scope"), MICROSOFT_MAIL_SCOPES.join(" "));
+});
+test("creates an opaque state and verifier pair", () => {
+	const first = createMicrosoftOAuthState();
+	const second = createMicrosoftOAuthState();
+	assert.match(first.state, /^[A-Za-z0-9_-]{32,}$/);
+	assert.match(first.codeVerifier, /^[A-Za-z0-9_-]{43,128}$/);
+	assert.notEqual(first.state, second.state);
+});
+test("exchanges a code and preserves refresh token rotation", async () => {
+	const calls: RequestInit[] = [];
+	const response = await exchangeMicrosoftAuthorizationCode(
+		{
+			clientId: "client-id",
+			clientSecret: "client-secret",
+			code: "auth-code",
+			codeVerifier: "verifier",
+			redirectUri: "https://app.example/callback",
+			tenant: "common",
+		},
+		async (_input, init) => {
+			calls.push(init ?? {});
+			return new Response(
+				JSON.stringify({
+					access_token: "access-token",
+					refresh_token: "rotated-refresh-token",
+					expires_in: 3600,
+					token_type: "Bearer",
+					scope: MICROSOFT_MAIL_SCOPES.join(" "),
+				}),
+				{ status: 200 },
+			);
+		},
+	);
+	assert.equal(response.accessToken, "access-token");
+	assert.equal(response.refreshToken, "rotated-refresh-token");
+	assert.equal(
+		new URLSearchParams(String(calls[0].body)).get("grant_type"),
+		"authorization_code",
+	);
+});
+test("reports actionable Microsoft refresh errors", async () => {
+	await assert.rejects(
+		refreshMicrosoftAccessToken(
+			{
+				clientId: "id",
+				clientSecret: "secret",
+				refreshToken: "refresh",
+				tenant: "common",
+			},
+			async () =>
+				new Response(
+					JSON.stringify({
+						error: "invalid_grant",
+						error_description: "AADSTS70008: expired",
+					}),
+					{ status: 400 },
+				),
+		),
+		/Microsoft authorization expired or was revoked.*reconnect/i,
+	);
+});
+test("formats the RFC 7628 XOAUTH2 initial client response", () => {
+	assert.equal(
+		xoauth2String("person@example.com", "access-token"),
+		"dXNlcj1wZXJzb25AZXhhbXBsZS5jb20BYXV0aD1CZWFyZXIgYWNjZXNzLXRva2VuAQE=",
+	);
+});
+
+test("validates callback state and token expiry skew", () => {
+	assert.equal(validateMicrosoftOAuthState("state", "state"), true);
+	assert.equal(validateMicrosoftOAuthState("state", "other"), false);
+	assert.equal(isMicrosoftTokenExpired(new Date(Date.now() + 10_000)), true);
+});

--- a/packages/providers/src/mail/microsoft-oauth.test.ts
+++ b/packages/providers/src/mail/microsoft-oauth.test.ts
@@ -8,6 +8,7 @@ import {
 	MICROSOFT_MAIL_SCOPES,
 	refreshMicrosoftAccessToken,
 	validateMicrosoftOAuthState,
+	withMicrosoftRefreshLock,
 	xoauth2String,
 } from "./microsoft-oauth";
 
@@ -28,6 +29,19 @@ test("builds Microsoft authorization URL with PKCE and state", () => {
 	assert.equal(url.searchParams.get("code_challenge_method"), "S256");
 	assert.equal(url.searchParams.get("state"), "state-value");
 	assert.equal(url.searchParams.get("scope"), MICROSOFT_MAIL_SCOPES.join(" "));
+});
+
+test("includes the nonce in the authorization request", () => {
+	const url = new URL(
+		buildMicrosoftAuthorizationUrl({
+			clientId: "client-id",
+			redirectUri: "https://app.example/callback",
+			state: "state-value",
+			codeChallenge: "challenge-value",
+			nonce: "nonce-value",
+		}),
+	);
+	assert.equal(url.searchParams.get("nonce"), "nonce-value");
 });
 test("creates an opaque state and verifier pair", () => {
 	const first = createMicrosoftOAuthState();
@@ -100,4 +114,55 @@ test("validates callback state and token expiry skew", () => {
 	assert.equal(validateMicrosoftOAuthState("state", "state"), true);
 	assert.equal(validateMicrosoftOAuthState("state", "other"), false);
 	assert.equal(isMicrosoftTokenExpired(new Date(Date.now() + 10_000)), true);
+});
+
+test("does not expose provider error descriptions", async () => {
+	await assert.rejects(
+		refreshMicrosoftAccessToken(
+			{ clientId: "id", refreshToken: "refresh", tenant: "common" },
+			async () =>
+				new Response(
+					JSON.stringify({
+						error: "temporarily_unavailable",
+						error_description: "secret tenant detail",
+					}),
+					{ status: 503 },
+				),
+		),
+		(error: unknown) =>
+			error instanceof Error &&
+			!error.message.includes("secret tenant detail") &&
+			error.message.includes("temporarily_unavailable"),
+	);
+});
+
+test("coalesces concurrent refreshes and persists the rotated token once", async () => {
+	let refreshes = 0;
+	let saves = 0;
+	const result = await Promise.all([
+		withMicrosoftRefreshLock(
+			"secret",
+			async () => {
+				refreshes++;
+				await new Promise((resolve) => setTimeout(resolve, 5));
+				return "token-1";
+			},
+			async () => {
+				saves++;
+			},
+		),
+		withMicrosoftRefreshLock(
+			"secret",
+			async () => {
+				refreshes++;
+				return "token-2";
+			},
+			async () => {
+				saves++;
+			},
+		),
+	]);
+	assert.deepEqual(result, ["token-1", "token-1"]);
+	assert.equal(refreshes, 1);
+	assert.equal(saves, 1);
 });

--- a/packages/providers/src/mail/microsoft-oauth.test.ts
+++ b/packages/providers/src/mail/microsoft-oauth.test.ts
@@ -1,14 +1,14 @@
-import test from "node:test";
 import assert from "node:assert/strict";
+import test from "node:test";
 import {
-	MICROSOFT_MAIL_SCOPES,
 	buildMicrosoftAuthorizationUrl,
 	createMicrosoftOAuthState,
 	exchangeMicrosoftAuthorizationCode,
-	refreshMicrosoftAccessToken,
-	xoauth2String,
 	isMicrosoftTokenExpired,
+	MICROSOFT_MAIL_SCOPES,
+	refreshMicrosoftAccessToken,
 	validateMicrosoftOAuthState,
+	xoauth2String,
 } from "./microsoft-oauth";
 
 test("builds Microsoft authorization URL with PKCE and state", () => {

--- a/packages/providers/src/mail/microsoft-oauth.test.ts
+++ b/packages/providers/src/mail/microsoft-oauth.test.ts
@@ -18,6 +18,7 @@ test("OAuth-created Microsoft credentials reach the refresh loader", async () =>
 	const credentials = createMicrosoftCredentials({
 		email: "person@example.com",
 		clientId: "client",
+		clientSecret: "client-secret",
 		tenant: "common",
 		token: {
 			accessToken: "expired-access",
@@ -43,6 +44,7 @@ test("OAuth-created Microsoft credentials reach the refresh loader", async () =>
 			),
 	});
 	assert.equal(result.provider, "microsoft");
+	assert.equal(result.MICROSOFT_CLIENT_SECRET, "client-secret");
 	assert.equal(result.IMAP_ACCESS_TOKEN, "fresh-access");
 	assert.equal(persisted?.MICROSOFT_REFRESH_TOKEN, "fresh-refresh");
 });

--- a/packages/providers/src/mail/microsoft-oauth.ts
+++ b/packages/providers/src/mail/microsoft-oauth.ts
@@ -20,6 +20,7 @@ export type MicrosoftTokenSet = {
 	expiresAt: Date;
 	scope?: string;
 	tokenType: string;
+	idToken?: string;
 };
 type Fetcher = typeof fetch;
 const endpoint = (tenant: string) =>
@@ -90,6 +91,7 @@ async function tokenRequest(
 		expiresAt: new Date(Date.now() + expiresIn * 1000),
 		scope: typeof data.scope === "string" ? data.scope : undefined,
 		tokenType: typeof data.token_type === "string" ? data.token_type : "Bearer",
+		idToken: typeof data.id_token === "string" ? data.id_token : undefined,
 	};
 }
 export function exchangeMicrosoftAuthorizationCode(

--- a/packages/providers/src/mail/microsoft-oauth.ts
+++ b/packages/providers/src/mail/microsoft-oauth.ts
@@ -153,6 +153,97 @@ export function xoauth2String(username: string, accessToken: string) {
 export function isMicrosoftTokenExpired(expiresAt: Date, skewSeconds = 60) {
 	return expiresAt.getTime() <= Date.now() + skewSeconds * 1000;
 }
+export type MicrosoftCredentials = Record<string, unknown>;
+
+export async function loadMicrosoftCredentials(
+	credentials: MicrosoftCredentials,
+	options: {
+		key: string;
+		persist: (
+			value: MicrosoftCredentials,
+			fenceToken?: string,
+		) => Promise<void>;
+		load?: () => Promise<MicrosoftCredentials | null>;
+		distributed?: boolean;
+		redis?: RefreshRedis;
+		leaseMs?: number;
+		renewEveryMs?: number;
+		fetcher?: Fetcher;
+	},
+): Promise<MicrosoftCredentials> {
+	const expiries = [
+		credentials.SMTP_TOKEN_EXPIRES_AT,
+		credentials.IMAP_TOKEN_EXPIRES_AT,
+	].filter((value): value is string => typeof value === "string");
+	if (
+		credentials.provider !== "microsoft" ||
+		typeof credentials.MICROSOFT_REFRESH_TOKEN !== "string" ||
+		expiries.length === 0 ||
+		expiries.every((value) => !isMicrosoftTokenExpired(new Date(value)))
+	)
+		return credentials;
+
+	const refreshed = await withMicrosoftRefreshLock(
+		options.key,
+		() =>
+			refreshMicrosoftAccessToken(
+				{
+					clientId: String(credentials.MICROSOFT_CLIENT_ID),
+					clientSecret:
+						typeof credentials.MICROSOFT_CLIENT_SECRET === "string"
+							? credentials.MICROSOFT_CLIENT_SECRET
+							: undefined,
+					refreshToken: String(credentials.MICROSOFT_REFRESH_TOKEN),
+					tenant: String(credentials.MICROSOFT_TENANT ?? "common"),
+				},
+				options.fetcher,
+			),
+		async (next, fenceToken) =>
+			options.persist(
+				{
+					...credentials,
+					SMTP_ACCESS_TOKEN: next.accessToken,
+					IMAP_ACCESS_TOKEN: next.accessToken,
+					MICROSOFT_REFRESH_TOKEN:
+						next.refreshToken ?? credentials.MICROSOFT_REFRESH_TOKEN,
+					SMTP_TOKEN_EXPIRES_AT: next.expiresAt.toISOString(),
+					IMAP_TOKEN_EXPIRES_AT: next.expiresAt.toISOString(),
+				},
+				fenceToken,
+			),
+		options.load
+			? async () => {
+					const current = await options.load?.();
+					const accessToken = current?.SMTP_ACCESS_TOKEN ?? current?.IMAP_ACCESS_TOKEN;
+					const expiresAt = current?.SMTP_TOKEN_EXPIRES_AT ?? current?.IMAP_TOKEN_EXPIRES_AT;
+					if (!accessToken || !expiresAt || isMicrosoftTokenExpired(new Date(String(expiresAt))))
+						return null;
+					return {
+						accessToken: String(accessToken),
+						refreshToken: String(current.MICROSOFT_REFRESH_TOKEN),
+						expiresAt: new Date(String(expiresAt)),
+						tokenType: "Bearer",
+					};
+				}
+			: undefined,
+		{
+			distributed: options.distributed,
+			redis: options.redis,
+			leaseMs: options.leaseMs,
+			renewEveryMs: options.renewEveryMs,
+		},
+	);
+	return {
+		...credentials,
+		SMTP_ACCESS_TOKEN: refreshed.accessToken,
+		IMAP_ACCESS_TOKEN: refreshed.accessToken,
+		MICROSOFT_REFRESH_TOKEN:
+			refreshed.refreshToken ?? credentials.MICROSOFT_REFRESH_TOKEN,
+		SMTP_TOKEN_EXPIRES_AT: refreshed.expiresAt.toISOString(),
+		IMAP_TOKEN_EXPIRES_AT: refreshed.expiresAt.toISOString(),
+	};
+}
+
 export function validateMicrosoftOAuthState(
 	expected: string,
 	received: string | null | undefined,
@@ -176,12 +267,12 @@ const getRefreshRedis = (): RefreshRedis => {
 			password: process.env.REDIS_PASSWORD,
 			maxRetriesPerRequest: null,
 		});
-	return refreshRedis;
+	return refreshRedis as unknown as RefreshRedis;
 };
 export function withMicrosoftRefreshLock<T>(
 	key: string,
 	refresh: () => Promise<T>,
-	persist: (value: T) => Promise<void>,
+	persist: (value: T, fenceToken?: string) => Promise<void>,
 	load?: () => Promise<T | null>,
 	options?: {
 		distributed?: boolean;
@@ -229,31 +320,45 @@ export function withMicrosoftRefreshLock<T>(
 			throw new Error("Microsoft refresh lock timed out");
 		}
 		let leaseLost = false;
-		const renewal = setInterval(() => {
-			void redis
-				.eval(
+		let renewal: Promise<void> | undefined;
+		const renew = async () => {
+			try {
+				const renewed = await redis.eval(
 					"if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('pexpire', KEYS[1], ARGV[2]) else return 0 end",
 					1,
 					lockKey,
 					owner,
 					String(leaseMs),
-				)
-				.then((renewed) => {
-					if (renewed !== 1) leaseLost = true;
-				})
-				.catch(() => {
-					leaseLost = true;
+				);
+				if (renewed !== 1) leaseLost = true;
+			} catch {
+				leaseLost = true;
+			}
+		};
+		const interval = setInterval(() => {
+			if (!renewal)
+				renewal = renew().finally(() => {
+					renewal = undefined;
 				});
 		}, renewEveryMs);
 		try {
 			const current = load ? await load() : null;
 			if (current) return current;
 			const value = await refresh();
+			if (renewal) await renewal;
 			if (leaseLost) throw new Error("Microsoft refresh lock lease lost");
-			await persist(value);
+			const fenced = await redis.eval(
+				"if redis.call('get', KEYS[1]) == ARGV[1] then return 1 else return 0 end",
+				1,
+				lockKey,
+				owner,
+			);
+			if (fenced !== 1) throw new Error("Microsoft refresh lock lease lost");
+			await persist(value, owner);
 			return value;
 		} finally {
-			clearInterval(renewal);
+			clearInterval(interval);
+			if (renewal) await renewal;
 			await redis.eval(
 				"if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end",
 				1,

--- a/packages/providers/src/mail/microsoft-oauth.ts
+++ b/packages/providers/src/mail/microsoft-oauth.ts
@@ -155,6 +155,36 @@ export function isMicrosoftTokenExpired(expiresAt: Date, skewSeconds = 60) {
 }
 export type MicrosoftCredentials = Record<string, unknown>;
 
+export function createMicrosoftCredentials(input: {
+	email: string;
+	clientId: string;
+	tenant: string;
+	token: MicrosoftTokenSet;
+}): MicrosoftCredentials {
+	const { email, clientId, tenant, token } = input;
+	return {
+		provider: "microsoft",
+		SMTP_HOST: "smtp.office365.com",
+		SMTP_PORT: "587",
+		SMTP_USERNAME: email,
+		SMTP_AUTH_METHOD: "xoauth2",
+		SMTP_ACCESS_TOKEN: token.accessToken,
+		SMTP_TOKEN_EXPIRES_AT: token.expiresAt.toISOString(),
+		SMTP_SECURE: "false",
+		IMAP_HOST: "outlook.office365.com",
+		IMAP_PORT: "993",
+		IMAP_USERNAME: email,
+		IMAP_AUTH_METHOD: "xoauth2",
+		IMAP_ACCESS_TOKEN: token.accessToken,
+		IMAP_TOKEN_EXPIRES_AT: token.expiresAt.toISOString(),
+		IMAP_SECURE: "true",
+		MICROSOFT_REFRESH_TOKEN: token.refreshToken,
+		MICROSOFT_TENANT: tenant,
+		MICROSOFT_CLIENT_ID: clientId,
+		MICROSOFT_SCOPES: MICROSOFT_MAIL_SCOPES.join(" "),
+	};
+}
+
 export async function loadMicrosoftCredentials(
 	credentials: MicrosoftCredentials,
 	options: {
@@ -214,13 +244,21 @@ export async function loadMicrosoftCredentials(
 		options.load
 			? async () => {
 					const current = await options.load?.();
-					const accessToken = current?.SMTP_ACCESS_TOKEN ?? current?.IMAP_ACCESS_TOKEN;
-					const expiresAt = current?.SMTP_TOKEN_EXPIRES_AT ?? current?.IMAP_TOKEN_EXPIRES_AT;
-					if (!accessToken || !expiresAt || isMicrosoftTokenExpired(new Date(String(expiresAt))))
+					const accessToken =
+						current?.SMTP_ACCESS_TOKEN ?? current?.IMAP_ACCESS_TOKEN;
+					const expiresAt =
+						current?.SMTP_TOKEN_EXPIRES_AT ?? current?.IMAP_TOKEN_EXPIRES_AT;
+					const refreshToken = current?.MICROSOFT_REFRESH_TOKEN;
+					if (
+						!accessToken ||
+						!expiresAt ||
+						typeof refreshToken !== "string" ||
+						isMicrosoftTokenExpired(new Date(String(expiresAt)))
+					)
 						return null;
 					return {
 						accessToken: String(accessToken),
-						refreshToken: String(current.MICROSOFT_REFRESH_TOKEN),
+						refreshToken,
 						expiresAt: new Date(String(expiresAt)),
 						tokenType: "Bearer",
 					};

--- a/packages/providers/src/mail/microsoft-oauth.ts
+++ b/packages/providers/src/mail/microsoft-oauth.ts
@@ -163,7 +163,12 @@ export function validateMicrosoftOAuthState(
 
 const microsoftRefreshes = new Map<string, Promise<unknown>>();
 let refreshRedis: IORedis | undefined;
-const getRefreshRedis = () => {
+type RefreshRedis = {
+	set: (...args: string[]) => Promise<string | null>;
+	pexpire: (key: string, milliseconds: number) => Promise<number>;
+	eval: (...args: unknown[]) => Promise<unknown>;
+};
+const getRefreshRedis = (): RefreshRedis => {
 	if (!refreshRedis)
 		refreshRedis = new IORedis({
 			host: process.env.REDIS_HOST || "redis",
@@ -178,7 +183,12 @@ export function withMicrosoftRefreshLock<T>(
 	refresh: () => Promise<T>,
 	persist: (value: T) => Promise<void>,
 	load?: () => Promise<T | null>,
-	options?: { distributed?: boolean },
+	options?: {
+		distributed?: boolean;
+		redis?: RefreshRedis;
+		leaseMs?: number;
+		renewEveryMs?: number;
+	},
 ): Promise<T> {
 	if (!options?.distributed) {
 		const existing = microsoftRefreshes.get(key);
@@ -197,9 +207,18 @@ export function withMicrosoftRefreshLock<T>(
 	}
 	const lockKey = `kurrier:microsoft-refresh-lock:${key}`;
 	const owner = crypto.randomUUID();
-	const redis = getRefreshRedis();
+	const redis = options.redis ?? getRefreshRedis();
+	const leaseMs = options.leaseMs ?? 30_000;
+	const renewEveryMs =
+		options.renewEveryMs ?? Math.max(1_000, Math.floor(leaseMs / 3));
 	return (async () => {
-		const acquired = await redis.set(lockKey, owner, "PX", 30_000, "NX");
+		const acquired = await redis.set(
+			lockKey,
+			owner,
+			"PX",
+			String(leaseMs),
+			"NX",
+		);
 		if (acquired !== "OK") {
 			if (!load) throw new Error("Microsoft refresh is already in progress");
 			for (let attempt = 0; attempt < 600; attempt++) {
@@ -209,13 +228,32 @@ export function withMicrosoftRefreshLock<T>(
 			}
 			throw new Error("Microsoft refresh lock timed out");
 		}
+		let leaseLost = false;
+		const renewal = setInterval(() => {
+			void redis
+				.eval(
+					"if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('pexpire', KEYS[1], ARGV[2]) else return 0 end",
+					1,
+					lockKey,
+					owner,
+					String(leaseMs),
+				)
+				.then((renewed) => {
+					if (renewed !== 1) leaseLost = true;
+				})
+				.catch(() => {
+					leaseLost = true;
+				});
+		}, renewEveryMs);
 		try {
 			const current = load ? await load() : null;
 			if (current) return current;
 			const value = await refresh();
+			if (leaseLost) throw new Error("Microsoft refresh lock lease lost");
 			await persist(value);
 			return value;
 		} finally {
+			clearInterval(renewal);
 			await redis.eval(
 				"if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end",
 				1,

--- a/packages/providers/src/mail/microsoft-oauth.ts
+++ b/packages/providers/src/mail/microsoft-oauth.ts
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import IORedis from "ioredis";
 
 export const MICROSOFT_MAIL_SCOPES = [
 	"openid",
@@ -31,6 +32,7 @@ export function createMicrosoftOAuthState() {
 	return {
 		state: encoded(crypto.randomBytes(32)),
 		codeVerifier: encoded(crypto.randomBytes(32)),
+		nonce: encoded(crypto.randomBytes(32)),
 	};
 }
 export function buildMicrosoftAuthorizationUrl(input: {
@@ -40,6 +42,7 @@ export function buildMicrosoftAuthorizationUrl(input: {
 	codeChallenge: string;
 	tenant?: string;
 	loginHint?: string;
+	nonce?: string;
 }) {
 	const url = new URL(
 		`https://login.microsoftonline.com/${encodeURIComponent(input.tenant ?? "common")}/oauth2/v2.0/authorize`,
@@ -53,6 +56,7 @@ export function buildMicrosoftAuthorizationUrl(input: {
 		code_challenge: input.codeChallenge,
 		code_challenge_method: "S256",
 		state: input.state,
+		...(input.nonce ? { nonce: input.nonce } : {}),
 		...(input.loginHint ? { login_hint: input.loginHint } : {}),
 	}).toString();
 	return url.toString();
@@ -74,14 +78,12 @@ async function tokenRequest(
 	const data = (await response.json()) as Record<string, unknown>;
 	if (!response.ok || typeof data.access_token !== "string") {
 		const code = String(data.error ?? "unknown_error");
-		const detail = String(
-			data.error_description ?? "Microsoft token request failed",
-		);
+		const detail = String(data.error_description ?? "");
 		if (code === "invalid_grant" || /expired|revoked|consent/i.test(detail))
 			throw new Error(
 				"Microsoft authorization expired or was revoked; reconnect the mailbox. ",
 			);
-		throw new Error(`Microsoft OAuth failed (${code}): ${detail}`);
+		throw new Error(`Microsoft OAuth failed (${code})`);
 	}
 	const expiresIn = Number(data.expires_in ?? 3600);
 	return {
@@ -157,4 +159,69 @@ export function validateMicrosoftOAuthState(
 ) {
 	if (!received || expected.length !== received.length) return false;
 	return crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(received));
+}
+
+const microsoftRefreshes = new Map<string, Promise<unknown>>();
+let refreshRedis: IORedis | undefined;
+const getRefreshRedis = () => {
+	if (!refreshRedis)
+		refreshRedis = new IORedis({
+			host: process.env.REDIS_HOST || "redis",
+			port: Number(process.env.REDIS_PORT || 6379),
+			password: process.env.REDIS_PASSWORD,
+			maxRetriesPerRequest: null,
+		});
+	return refreshRedis;
+};
+export function withMicrosoftRefreshLock<T>(
+	key: string,
+	refresh: () => Promise<T>,
+	persist: (value: T) => Promise<void>,
+	load?: () => Promise<T | null>,
+	options?: { distributed?: boolean },
+): Promise<T> {
+	if (!options?.distributed) {
+		const existing = microsoftRefreshes.get(key);
+		if (existing) return existing as Promise<T>;
+		const operation = refresh()
+			.then(async (value) => {
+				await persist(value);
+				return value;
+			})
+			.finally(() => {
+				if (microsoftRefreshes.get(key) === operation)
+					microsoftRefreshes.delete(key);
+			});
+		microsoftRefreshes.set(key, operation);
+		return operation;
+	}
+	const lockKey = `kurrier:microsoft-refresh-lock:${key}`;
+	const owner = crypto.randomUUID();
+	const redis = getRefreshRedis();
+	return (async () => {
+		const acquired = await redis.set(lockKey, owner, "PX", 30_000, "NX");
+		if (acquired !== "OK") {
+			if (!load) throw new Error("Microsoft refresh is already in progress");
+			for (let attempt = 0; attempt < 600; attempt++) {
+				const value = await load();
+				if (value) return value;
+				await new Promise((resolve) => setTimeout(resolve, 50));
+			}
+			throw new Error("Microsoft refresh lock timed out");
+		}
+		try {
+			const current = load ? await load() : null;
+			if (current) return current;
+			const value = await refresh();
+			await persist(value);
+			return value;
+		} finally {
+			await redis.eval(
+				"if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end",
+				1,
+				lockKey,
+				owner,
+			);
+		}
+	})();
 }

--- a/packages/providers/src/mail/microsoft-oauth.ts
+++ b/packages/providers/src/mail/microsoft-oauth.ts
@@ -158,10 +158,11 @@ export type MicrosoftCredentials = Record<string, unknown>;
 export function createMicrosoftCredentials(input: {
 	email: string;
 	clientId: string;
+	clientSecret?: string;
 	tenant: string;
 	token: MicrosoftTokenSet;
 }): MicrosoftCredentials {
-	const { email, clientId, tenant, token } = input;
+	const { email, clientId, clientSecret, tenant, token } = input;
 	return {
 		provider: "microsoft",
 		SMTP_HOST: "smtp.office365.com",
@@ -181,6 +182,7 @@ export function createMicrosoftCredentials(input: {
 		MICROSOFT_REFRESH_TOKEN: token.refreshToken,
 		MICROSOFT_TENANT: tenant,
 		MICROSOFT_CLIENT_ID: clientId,
+		...(clientSecret ? { MICROSOFT_CLIENT_SECRET: clientSecret } : {}),
 		MICROSOFT_SCOPES: MICROSOFT_MAIL_SCOPES.join(" "),
 	};
 }

--- a/packages/providers/src/mail/microsoft-oauth.ts
+++ b/packages/providers/src/mail/microsoft-oauth.ts
@@ -1,0 +1,158 @@
+import crypto from "node:crypto";
+
+export const MICROSOFT_MAIL_SCOPES = [
+	"openid",
+	"profile",
+	"email",
+	"offline_access",
+	"https://outlook.office.com/IMAP.AccessAsUser.All",
+	"https://outlook.office.com/SMTP.Send",
+] as const;
+export type MicrosoftOAuthConfig = {
+	clientId: string;
+	clientSecret?: string;
+	tenant: string;
+	redirectUri?: string;
+};
+export type MicrosoftTokenSet = {
+	accessToken: string;
+	refreshToken?: string;
+	expiresAt: Date;
+	scope?: string;
+	tokenType: string;
+};
+type Fetcher = typeof fetch;
+const endpoint = (tenant: string) =>
+	`https://login.microsoftonline.com/${encodeURIComponent(tenant)}/oauth2/v2.0/token`;
+const encoded = (value: Buffer) => value.toString("base64url");
+
+export function createMicrosoftOAuthState() {
+	return {
+		state: encoded(crypto.randomBytes(32)),
+		codeVerifier: encoded(crypto.randomBytes(32)),
+	};
+}
+export function buildMicrosoftAuthorizationUrl(input: {
+	clientId: string;
+	redirectUri: string;
+	state: string;
+	codeChallenge: string;
+	tenant?: string;
+	loginHint?: string;
+}) {
+	const url = new URL(
+		`https://login.microsoftonline.com/${encodeURIComponent(input.tenant ?? "common")}/oauth2/v2.0/authorize`,
+	);
+	url.search = new URLSearchParams({
+		client_id: input.clientId,
+		response_type: "code",
+		redirect_uri: input.redirectUri,
+		response_mode: "query",
+		scope: MICROSOFT_MAIL_SCOPES.join(" "),
+		code_challenge: input.codeChallenge,
+		code_challenge_method: "S256",
+		state: input.state,
+		...(input.loginHint ? { login_hint: input.loginHint } : {}),
+	}).toString();
+	return url.toString();
+}
+async function tokenRequest(
+	config: MicrosoftOAuthConfig,
+	params: Record<string, string>,
+	fetcher: Fetcher,
+): Promise<MicrosoftTokenSet> {
+	const response = await fetcher(endpoint(config.tenant), {
+		method: "POST",
+		headers: { "content-type": "application/x-www-form-urlencoded" },
+		body: new URLSearchParams({
+			client_id: config.clientId,
+			...(config.clientSecret ? { client_secret: config.clientSecret } : {}),
+			...params,
+		}).toString(),
+	});
+	const data = (await response.json()) as Record<string, unknown>;
+	if (!response.ok || typeof data.access_token !== "string") {
+		const code = String(data.error ?? "unknown_error");
+		const detail = String(
+			data.error_description ?? "Microsoft token request failed",
+		);
+		if (code === "invalid_grant" || /expired|revoked|consent/i.test(detail))
+			throw new Error(
+				"Microsoft authorization expired or was revoked; reconnect the mailbox. ",
+			);
+		throw new Error(`Microsoft OAuth failed (${code}): ${detail}`);
+	}
+	const expiresIn = Number(data.expires_in ?? 3600);
+	return {
+		accessToken: data.access_token,
+		refreshToken:
+			typeof data.refresh_token === "string" ? data.refresh_token : undefined,
+		expiresAt: new Date(Date.now() + expiresIn * 1000),
+		scope: typeof data.scope === "string" ? data.scope : undefined,
+		tokenType: typeof data.token_type === "string" ? data.token_type : "Bearer",
+	};
+}
+export function exchangeMicrosoftAuthorizationCode(
+	input: {
+		clientId: string;
+		clientSecret?: string;
+		code: string;
+		codeVerifier: string;
+		redirectUri: string;
+		tenant?: string;
+	},
+	fetcher: Fetcher = fetch,
+) {
+	return tokenRequest(
+		{
+			clientId: input.clientId,
+			clientSecret: input.clientSecret,
+			tenant: input.tenant ?? "common",
+		},
+		{
+			grant_type: "authorization_code",
+			code: input.code,
+			code_verifier: input.codeVerifier,
+			redirect_uri: input.redirectUri,
+		},
+		fetcher,
+	);
+}
+export function refreshMicrosoftAccessToken(
+	input: {
+		clientId: string;
+		clientSecret?: string;
+		refreshToken: string;
+		tenant?: string;
+	},
+	fetcher: Fetcher = fetch,
+) {
+	return tokenRequest(
+		{
+			clientId: input.clientId,
+			clientSecret: input.clientSecret,
+			tenant: input.tenant ?? "common",
+		},
+		{
+			grant_type: "refresh_token",
+			refresh_token: input.refreshToken,
+			scope: MICROSOFT_MAIL_SCOPES.join(" "),
+		},
+		fetcher,
+	);
+}
+export function xoauth2String(username: string, accessToken: string) {
+	return Buffer.from(
+		`user=${username}\x01auth=Bearer ${accessToken}\x01\x01`,
+	).toString("base64");
+}
+export function isMicrosoftTokenExpired(expiresAt: Date, skewSeconds = 60) {
+	return expiresAt.getTime() <= Date.now() + skewSeconds * 1000;
+}
+export function validateMicrosoftOAuthState(
+	expected: string,
+	received: string | null | undefined,
+) {
+	if (!received || expected.length !== received.length) return false;
+	return crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(received));
+}

--- a/packages/providers/src/mail/smtp.ts
+++ b/packages/providers/src/mail/smtp.ts
@@ -27,10 +27,10 @@ export class SmtpMailer implements Mailer {
 				host: cfg.imap.host,
 				port: cfg.imap.port,
 				secure: cfg.imap.secure,
-				auth: {
-					user: cfg.imap.user,
-					pass: cfg.imap.pass,
-				},
+				auth:
+					cfg.imap.authMethod === "xoauth2"
+						? { user: cfg.imap.user, accessToken: cfg.imap.accessToken! }
+						: { user: cfg.imap.user, pass: cfg.imap.pass! },
 			})
 			: null;
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -548,6 +548,9 @@ importers:
       imapflow:
         specifier: ^1.0.198
         version: 1.2.0
+      ioredis:
+        specifier: ^5.8.1
+        version: 5.11.1
       mailgun.js:
         specifier: ^12.1.0
         version: 12.4.0
@@ -5110,6 +5113,7 @@ packages:
   eslint@9.39.2:
     resolution: {integrity: sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -16125,7 +16129,7 @@ snapshots:
       h3: 1.15.4
       hookable: 5.5.3
       httpxy: 0.1.7
-      ioredis: 5.8.2
+      ioredis: 5.11.1
       jiti: 2.6.1
       klona: 2.0.6
       knitwork: 1.3.0
@@ -16158,7 +16162,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       unimport: 5.5.0
       unplugin-utils: 0.3.1
-      unstorage: 1.17.2(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.4.5)(drizzle-orm@0.45.2(@libsql/client@0.15.15)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.4.5)(pg@8.16.3)(postgres@3.4.7)))(ioredis@5.8.2)
+      unstorage: 1.17.2(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.4.5)(drizzle-orm@0.45.2(@libsql/client@0.15.15)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.4.5)(pg@8.16.3)(postgres@3.4.7)))(ioredis@5.11.1)
       untyped: 2.0.0
       unwasm: 0.3.11
       youch: 4.1.0-beta.12
@@ -18015,7 +18019,7 @@ snapshots:
       '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
       '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
 
-  unstorage@1.17.2(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.4.5)(drizzle-orm@0.45.2(@libsql/client@0.15.15)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.4.5)(pg@8.16.3)(postgres@3.4.7)))(ioredis@5.8.2):
+  unstorage@1.17.2(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.4.5)(drizzle-orm@0.45.2(@libsql/client@0.15.15)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.4.5)(pg@8.16.3)(postgres@3.4.7)))(ioredis@5.11.1):
     dependencies:
       anymatch: 3.1.3
       chokidar: 4.0.3
@@ -18027,7 +18031,7 @@ snapshots:
       ufo: 1.6.1
     optionalDependencies:
       db0: 0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.4.5)(drizzle-orm@0.45.2(@libsql/client@0.15.15)(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.4.5)(pg@8.16.3)(postgres@3.4.7))
-      ioredis: 5.8.2
+      ioredis: 5.11.1
 
   untun@0.1.3:
     dependencies:


### PR DESCRIPTION
## Summary
- add user-facing Microsoft 365 delegated OAuth connect and callback routes with PKCE/state cookies
- persist access and refresh tokens through the encrypted secret vault as XOAUTH2 SMTP/IMAP credentials
- refresh expired Microsoft access tokens and persist rotated refresh tokens
- add Microsoft 365 provider card and documentation-ready configuration behavior

Closes #633

## Verification
- `pnpm exec tsx --test packages/providers/src/mail/microsoft-oauth.test.ts` — 6 passing
- `pnpm --filter @kurrier/web exec tsc --noEmit` — blocked by two pre-existing mailbox type errors
- `pnpm --filter @kurrier/web build` — blocked because required rewrite environment variables are unset

No real Microsoft credentials were used.