### PR TITLE
fix(imap): scope synthetic parent mailboxes to identity workspace

### DIFF
--- a/apps/worker/lib/imap/backfill/discover/discover-helpers.test.ts
+++ b/apps/worker/lib/imap/backfill/discover/discover-helpers.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createParentMailboxValues } from "./discover-helpers";
+
+test("creates a missing IMAP parent mailbox in the identity workspace", () => {
+	const workspaceId = "11111111-1111-4111-8111-111111111111";
+	const values = createParentMailboxValues({
+		identity: {
+			id: "22222222-2222-4222-8222-222222222222",
+			ownerId: "33333333-3333-4333-8333-333333333333",
+			workspaceId,
+		},
+		parentPath: "INBOX",
+		parentId: null,
+		delimiter: ".",
+	});
+
+	assert.equal(values.workspaceId, workspaceId);
+	assert.equal(values.identityId, "22222222-2222-4222-8222-222222222222");
+	assert.equal(values.metaData.imap.path, "INBOX");
+	assert.equal(values.metaData.imap.selectable, false);
+});

--- a/apps/worker/lib/imap/backfill/discover/discover-helpers.ts
+++ b/apps/worker/lib/imap/backfill/discover/discover-helpers.ts
@@ -1,7 +1,7 @@
-import { db, mailboxes, type IdentityEntity, type MailboxEntity } from "@db";
-import { and, eq, sql } from "drizzle-orm";
+import { db, type IdentityEntity, type MailboxEntity, mailboxes } from "@db";
+import type { MailboxKind } from "@schema";
 import slugify from "@sindresorhus/slugify";
-import { MailboxKind } from "@schema";
+import { and, eq, sql } from "drizzle-orm";
 
 export type PathIdMap = Map<string, string>;
 
@@ -24,6 +24,41 @@ export async function findLocalByPath(identityId: string, path: string) {
 	return row as MailboxEntity | undefined;
 }
 
+export function createParentMailboxValues(opts: {
+	identity: Pick<IdentityEntity, "id" | "ownerId" | "workspaceId">;
+	parentPath: string;
+	parentId: string | null;
+	delimiter: string;
+}): typeof mailboxes.$inferInsert {
+	const { identity, parentPath, parentId, delimiter } = opts;
+	const { parentPath: grandparentPath, name: parentName } = splitParent(
+		parentPath,
+		delimiter,
+	);
+
+	return {
+		ownerId: identity.ownerId,
+		workspaceId: identity.workspaceId,
+		identityId: identity.id,
+		parentId,
+		name: parentName,
+		slug: slugify(parentPath),
+		kind: "custom" as const,
+		isDefault: false,
+		metaData: {
+			imap: {
+				path: parentPath,
+				name: parentName,
+				parentPath: grandparentPath,
+				delimiter,
+				flags: ["\\Noselect"],
+				specialUse: null,
+				selectable: false,
+			},
+		},
+	};
+}
+
 export async function ensureParentChain(opts: {
 	identity: IdentityEntity;
 	parentPath: string;
@@ -43,10 +78,7 @@ export async function ensureParentChain(opts: {
 		return existing.id;
 	}
 
-	const { parentPath: pp2, name: parentName } = splitParent(
-		parentPath,
-		delimiter,
-	);
+	const { parentPath: pp2 } = splitParent(parentPath, delimiter);
 	const grandId = await ensureParentChain({
 		identity,
 		parentPath: pp2,
@@ -56,26 +88,14 @@ export async function ensureParentChain(opts: {
 
 	const [parentRow] = await db
 		.insert(mailboxes)
-		.values({
-			ownerId: identity.ownerId,
-			identityId: identity.id,
-			parentId: grandId,
-			name: parentName,
-			slug: slugify(parentPath),
-			kind: "custom",
-			isDefault: false,
-			metaData: {
-				imap: {
-					path: parentPath,
-					name: parentName,
-					parentPath: pp2,
-					delimiter,
-					flags: ["\\Noselect"],
-					specialUse: null,
-					selectable: false,
-				},
-			},
-		} as any)
+		.values(
+			createParentMailboxValues({
+				identity,
+				parentPath,
+				parentId: grandId,
+				delimiter,
+			}),
+		)
 		.returning();
 
 	pathIdMap.set(parentPath, parentRow.id);


### PR DESCRIPTION
## Summary
- Persist the workspace ID when IMAP discovery synthesizes non-selectable parent mailboxes.
- Avoid relying on the worker's request JWT workspace default during background mailbox discovery.
- Add a regression test for a synthesized `INBOX` parent mailbox.

## Root cause
`ensureParentChain` inserted `mailboxes` rows without `workspaceId`. The database default reads `request.jwt.claim.workspace_id`, which is unavailable or unreliable in worker jobs. This caused SMTP/IMAP identity creation to fail for mailbox trees requiring a synthetic `\Noselect` parent.

## Validation
- `pnpm --dir apps/worker exec tsx --tsconfig tsconfig.json --test lib/imap/backfill/discover/discover-helpers.test.ts`
- `pnpm exec biome check apps/worker/lib/imap/backfill/discover/discover-helpers.ts apps/worker/lib/imap/backfill/discover/discover-helpers.test.ts`
- Synthetic `pnpm --dir apps/worker run build` with inert `.invalid` service endpoints.
- `git diff --check`

`pnpm run lint` remains blocked by pre-existing repository-wide diagnostics outside this change (604 errors, 994 warnings). The changed files pass their targeted Biome check.

## Resolves
Fixes #646

## AI assistance disclosure
I prepared and verified this change with Hermes Agent, then independently reviewed it before submission.

## Manual validation
I built and ran the Docker images on my own server, then manually tested adding an OVH-hosted mailbox that previously could not be added. After this change, identity setup and mailbox discovery completed successfully.